### PR TITLE
Add HDF5/NeXus schema document

### DIFF
--- a/docs/hdf5_schema.md
+++ b/docs/hdf5_schema.md
@@ -158,7 +158,7 @@ If either metadata field is missing, `energy_eV` must be absent.
 Relationship between TOF and energy:
 
 Mantid defines energy conversion from TOF using the non-relativistic relation
-`E = (m_n / 2) * (L_tot / t)^2`, where `t` is the time-of-flight and `L_tot` is
+`E = (m_n / 2) * (L / t)^2`, where `t` is the time-of-flight and `L` is
 source-to-detector flight path.
 
 For rustpix, use:


### PR DESCRIPTION
## Summary
- add docs/hdf5_schema.md defining the HDF5/NeXus layout for events and histograms
- specify required/optional datasets, units, axes conventions, and round-trip expectations

## Testing
- not applicable (doc-only change)