### PR TITLE
Docs: rustpix-core public API

### DIFF
--- a/rustpix-core/src/clustering.rs
+++ b/rustpix-core/src/clustering.rs
@@ -84,11 +84,17 @@ impl ClusteringConfig {
 /// Statistics from a clustering operation.
 #[derive(Clone, Debug, Default)]
 pub struct ClusteringStatistics {
+    /// Total number of hits processed.
     pub hits_processed: usize,
+    /// Number of clusters found.
     pub clusters_found: usize,
+    /// Number of hits classified as noise.
     pub noise_hits: usize,
+    /// Size of the largest cluster encountered.
     pub largest_cluster_size: usize,
+    /// Mean size of clusters.
     pub mean_cluster_size: f64,
+    /// Processing time in microseconds.
     pub processing_time_us: u64,
 }
 

--- a/rustpix-core/src/error.rs
+++ b/rustpix-core/src/error.rs
@@ -5,12 +5,15 @@ use thiserror::Error;
 /// Errors during clustering operations.
 #[derive(Error, Debug)]
 pub enum ClusteringError {
+    /// No hits provided for clustering.
     #[error("empty input: cannot cluster zero hits")]
     EmptyInput,
 
+    /// Invalid clustering configuration.
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
 
+    /// Internal state error while clustering.
     #[error("state error: {0}")]
     StateError(String),
 }
@@ -18,9 +21,11 @@ pub enum ClusteringError {
 /// Errors during extraction operations.
 #[derive(Error, Debug)]
 pub enum ExtractionError {
+    /// Cluster is empty when extraction is attempted.
     #[error("empty cluster: cannot extract from zero hits")]
     EmptyCluster,
 
+    /// Invalid extraction configuration.
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
 }
@@ -28,15 +33,19 @@ pub enum ExtractionError {
 /// Errors during I/O operations.
 #[derive(Error, Debug)]
 pub enum IoError {
+    /// File path does not exist.
     #[error("file not found: {0}")]
     FileNotFound(String),
 
+    /// File data did not match expected format.
     #[error("invalid file format: {0}")]
     InvalidFormat(String),
 
+    /// Memory-mapped file failed to initialize.
     #[error("memory mapping failed: {0}")]
     MmapError(String),
 
+    /// Underlying I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -44,15 +53,24 @@ pub enum IoError {
 /// Errors during TPX3 processing.
 #[derive(Error, Debug)]
 pub enum ProcessingError {
+    /// Underlying I/O error during processing.
     #[error("I/O error: {0}")]
     Io(#[from] IoError),
 
+    /// Packet failed validation.
     #[error("invalid packet at offset {offset}: {message}")]
-    InvalidPacket { offset: usize, message: String },
+    InvalidPacket {
+        /// Byte offset where the invalid packet was detected.
+        offset: usize,
+        /// Validation error description.
+        message: String,
+    },
 
+    /// TDC reference missing for a data section.
     #[error("missing TDC reference for section starting at offset {0}")]
     MissingTdc(usize),
 
+    /// Invalid or inconsistent processing configuration.
     #[error("configuration error: {0}")]
     Config(String),
 }
@@ -60,15 +78,19 @@ pub enum ProcessingError {
 /// Combined error type for the library.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Error from clustering stage.
     #[error("clustering error: {0}")]
     Clustering(#[from] ClusteringError),
 
+    /// Error from extraction stage.
     #[error("extraction error: {0}")]
     Extraction(#[from] ExtractionError),
 
+    /// Error from I/O operations.
     #[error("I/O error: {0}")]
     Io(#[from] IoError),
 
+    /// Error from TPX3 processing pipeline.
     #[error("processing error: {0}")]
     Processing(#[from] ProcessingError),
 }

--- a/rustpix-core/src/lib.rs
+++ b/rustpix-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides the foundational abstractions for hit detection,
 //! neutron processing, clustering, and centroid extraction.
 //!
+#![warn(missing_docs)]
 
 pub mod clustering;
 pub mod error;

--- a/rustpix-core/src/neutron.rs
+++ b/rustpix-core/src/neutron.rs
@@ -75,38 +75,58 @@ impl Neutron {
 /// Cluster size categories for analysis.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ClusterSize {
+    /// Single-hit cluster.
     Single,
+    /// Small cluster (2-4 hits).
     Small,
+    /// Medium cluster (5-10 hits).
     Medium,
+    /// Large cluster (>10 hits).
     Large,
 }
 
 /// Statistics for a collection of neutrons.
 #[derive(Clone, Debug, Default)]
 pub struct NeutronStatistics {
+    /// Number of neutrons in the sample.
     pub count: usize,
+    /// Mean time-of-flight (25ns units).
     pub mean_tof: f64,
+    /// Standard deviation of time-of-flight (25ns units).
     pub std_tof: f64,
+    /// Mean time-over-threshold.
     pub mean_tot: f64,
+    /// Mean cluster size (hits per neutron).
     pub mean_cluster_size: f64,
+    /// Fraction of single-hit neutrons.
     pub single_hit_fraction: f64,
+    /// Min/max X coordinate.
     pub x_range: (f64, f64),
+    /// Min/max Y coordinate.
     pub y_range: (f64, f64),
+    /// Min/max time-of-flight (25ns units).
     pub tof_range: (u32, u32),
 }
 
 /// Structure-of-arrays neutron output.
 #[derive(Clone, Debug, Default)]
 pub struct NeutronBatch {
+    /// X coordinates (super-resolution space).
     pub x: Vec<f64>,
+    /// Y coordinates (super-resolution space).
     pub y: Vec<f64>,
+    /// Time-of-flight values (25ns units).
     pub tof: Vec<u32>,
+    /// Time-over-threshold values.
     pub tot: Vec<u16>,
+    /// Number of hits per neutron.
     pub n_hits: Vec<u16>,
+    /// Chip ID per neutron.
     pub chip_id: Vec<u8>,
 }
 
 impl NeutronBatch {
+    /// Create a batch with pre-allocated capacity.
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -119,16 +139,19 @@ impl NeutronBatch {
         }
     }
 
+    /// Number of neutrons in the batch.
     #[must_use]
     pub fn len(&self) -> usize {
         self.x.len()
     }
 
+    /// Returns true when the batch is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.x.is_empty()
     }
 
+    /// Append a single neutron to the batch.
     pub fn push(&mut self, neutron: Neutron) {
         self.x.push(neutron.x);
         self.y.push(neutron.y);
@@ -138,6 +161,7 @@ impl NeutronBatch {
         self.chip_id.push(neutron.chip_id);
     }
 
+    /// Append all neutrons from another batch.
     pub fn append(&mut self, other: &NeutronBatch) {
         self.x.extend_from_slice(&other.x);
         self.y.extend_from_slice(&other.y);
@@ -147,6 +171,7 @@ impl NeutronBatch {
         self.chip_id.extend_from_slice(&other.chip_id);
     }
 
+    /// Clear all neutron data from the batch.
     pub fn clear(&mut self) {
         self.x.clear();
         self.y.clear();


### PR DESCRIPTION
Summary
- enable missing_docs lint for rustpix-core
- document core clustering stats, error variants, and neutron data structures

Testing
- pixi run lint

Closes #69
