### PR TITLE
[TEST] Add unit test for super-resolution factor in extraction

### DIFF
--- a/rustpix-core/src/extraction.rs
+++ b/rustpix-core/src/extraction.rs
@@ -669,4 +669,30 @@ mod tests {
         assert_eq!(n1.n_hits, 1);
         assert_eq!(n1.chip_id, 1);
     }
+
+    #[test]
+    fn test_super_resolution_factor_affects_output() {
+        let batch = make_batch(&[(1000, 2, 3, 500, 20, 0, 0)]);
+
+        let mut extractor = SimpleCentroidExtraction::new();
+        extractor.configure(
+            ExtractionConfig::default()
+                .with_super_resolution(1.0)
+                .with_min_tot_threshold(0),
+        );
+        let neutrons = extractor.extract_soa(&batch, 1).unwrap();
+        assert_eq!(neutrons.len(), 1);
+        assert!((neutrons[0].x - 2.0).abs() < f64::EPSILON);
+        assert!((neutrons[0].y - 3.0).abs() < f64::EPSILON);
+
+        extractor.configure(
+            ExtractionConfig::default()
+                .with_super_resolution(4.0)
+                .with_min_tot_threshold(0),
+        );
+        let neutrons = extractor.extract_soa(&batch, 1).unwrap();
+        assert_eq!(neutrons.len(), 1);
+        assert!((neutrons[0].x - 8.0).abs() < f64::EPSILON);
+        assert!((neutrons[0].y - 12.0).abs() < f64::EPSILON);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a unit test to verify that the super-resolution factor correctly affects neutron extraction output positions.

## Context

Issue #84 reported that the super-resolution setting appeared to have no effect. Investigation confirmed the implementation is correct - the super-resolution factor is properly applied during extraction. This PR adds test coverage to prevent regressions.

## Changes

- Added `test_super_resolution_factor_affects_output` in `rustpix-core/src/extraction.rs`
- Test verifies that higher super-resolution factors produce different (sub-pixel) centroid positions

## Related Issues

Closes #84 - Super-resolution setting in clustering has no effect

## Test Plan

- [x] `cargo test -p rustpix-core test_super_resolution` passes
- [x] `pixi run clippy` produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)