### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2024-XX-XX
+## [1.0.0] - 2026-02-03
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-algorithms"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "approx",
  "rayon",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "rayon",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "approx",
  "serde",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-gui"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "eframe",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-io"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "hdf5-metno",
  "memmap2",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-python"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "numpy",
  "pyo3",
@@ -3864,11 +3864,11 @@ dependencies = [
 
 [[package]]
 name = "rustpix-tools"
-version = "0.1.0"
+version = "1.0.0"
 
 [[package]]
 name = "rustpix-tpx"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "approx",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["ORNL Neutron Imaging <neutronimaging@ornl.gov>"]
 license = "MIT"
@@ -30,10 +30,10 @@ categories = ["science", "data-structures", "parsing"]
 
 [workspace.dependencies]
 # Internal crates (version for crates.io, path for local dev)
-rustpix-core = { version = "0.1.0", path = "rustpix-core" }
-rustpix-tpx = { version = "0.1.0", path = "rustpix-tpx" }
-rustpix-algorithms = { version = "0.1.0", path = "rustpix-algorithms" }
-rustpix-io = { version = "0.1.0", path = "rustpix-io" }
+rustpix-core = { version = "1.0.0", path = "rustpix-core" }
+rustpix-tpx = { version = "1.0.0", path = "rustpix-tpx" }
+rustpix-algorithms = { version = "1.0.0", path = "rustpix-algorithms" }
+rustpix-io = { version = "1.0.0", path = "rustpix-io" }
 
 # Parallelism
 rayon = "1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustpix"
-version = "0.1.0"
+version = "1.0.0"
 description = "High-performance TPX3 pixel detector data processing for neutron imaging"
 authors = [{ name = "ORNL Neutron Imaging", email = "neutronimaging@ornl.gov" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## Version Bump for v1.0.0 Release

Updates all version numbers from 0.1.0 to 1.0.0 in preparation for the first major release.

### Changes
- ✅ Cargo.toml - workspace version and dependencies updated to 1.0.0
- ✅ pyproject.toml - Python package version updated to 1.0.0
- ✅ Cargo.lock - dependency versions synchronized
- ✅ CHANGELOG.md - release date set to 2026-02-03

### Release Checklist
- [x] Release infrastructure (PR #107)
- [x] Manual PyPI publishing (v0.1.0 test)
- [x] PyPI trusted publishing configured
- [x] Version bumped to 1.0.0
- [ ] Merge this PR to main
- [ ] Tag v1.0.0 on main branch
- [ ] Automated release workflow

### What Happens After Merge

Once this PR is merged and tagged with `v1.0.0`, the automated release workflow will:
1. Build Python wheels for all platforms (Linux, macOS x86_64/ARM64, Windows)
2. Build CLI binaries for all platforms
3. Build macOS .app bundle with DMG
4. Publish to PyPI (via trusted publishing)
5. Publish to crates.io
6. Create GitHub Release with all binaries
7. Update Homebrew tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)