### PR TITLE
fix: v1.0.2 - LICENSE file in PyPI distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-02-03
+
+### Fixed
+
+- PyPI metadata: Fixed LICENSE file inclusion in source distribution
+
 ## [1.0.1] - 2026-02-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-algorithms"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "approx",
  "rayon",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "rayon",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "approx",
  "serde",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-gui"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "eframe",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-io"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "hdf5-metno",
  "memmap2",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-python"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "numpy",
  "pyo3",
@@ -3864,11 +3864,11 @@ dependencies = [
 
 [[package]]
 name = "rustpix-tools"
-version = "1.0.1"
+version = "1.0.2"
 
 [[package]]
 name = "rustpix-tpx"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "approx",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["ORNL Neutron Imaging <neutronimaging@ornl.gov>"]
 license = "MIT"
@@ -30,10 +30,10 @@ categories = ["science", "data-structures", "parsing"]
 
 [workspace.dependencies]
 # Internal crates (version for crates.io, path for local dev)
-rustpix-core = { version = "1.0.1", path = "rustpix-core" }
-rustpix-tpx = { version = "1.0.1", path = "rustpix-tpx" }
-rustpix-algorithms = { version = "1.0.1", path = "rustpix-algorithms" }
-rustpix-io = { version = "1.0.1", path = "rustpix-io" }
+rustpix-core = { version = "1.0.2", path = "rustpix-core" }
+rustpix-tpx = { version = "1.0.2", path = "rustpix-tpx" }
+rustpix-algorithms = { version = "1.0.2", path = "rustpix-algorithms" }
+rustpix-io = { version = "1.0.2", path = "rustpix-io" }
 
 # Parallelism
 rayon = "1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "rustpix"
-version = "1.0.1"
+version = "1.0.2"
 description = "High-performance TPX3 pixel detector data processing for neutron imaging"
 authors = [{ name = "ORNL Neutron Imaging", email = "neutronimaging@ornl.gov" }]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## v1.0.2 Patch Release

Fixes LICENSE file inclusion in PyPI source distribution.

### Issue

v1.0.1 PyPI upload failed with:
```
ERROR HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
License-File LICENSE does not exist in distribution file
rustpix-1.0.1.tar.gz at rustpix-1.0.1/LICENSE
```

### Fix

Changed pyproject.toml license metadata:
- **Before**: `license = { text = "MIT" }`
- **After**: `license = { file = "LICENSE" }`

This properly includes the LICENSE file in the sdist tarball.

### Version Bump

- 1.0.1 → 1.0.2 (required since PyPI doesn't allow republishing)

### Verification

Tested locally:
```bash
$ pixi run maturin sdist -m rustpix-python/Cargo.toml --out /tmp
$ tar -tzf /tmp/rustpix-1.0.2.tar.gz | grep LICENSE
rustpix-1.0.2/LICENSE  ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)