### PR TITLE
fix: exclude rustpix-python from macOS app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         run: cargo install cargo-bundle
 
       - name: Build macOS app bundle
-        run: cargo bundle --release --package rustpix-gui
+        run: cargo bundle --release --package rustpix-gui --exclude rustpix-python
 
       - name: Create DMG
         run: |


### PR DESCRIPTION
## macOS App Bundle Fix

Fixes build failure in `build-macos-app` job.

### Issue

cargo-bundle was attempting to build all workspace members including `rustpix-python`, which caused linker errors:
```
undefined symbols: _PyErr_*, _PyExc_*, etc.
error: could not compile `rustpix-python` (lib) due to 1 previous error
```

### Root Cause

The GUI doesn't depend on Python bindings, but cargo-bundle was building the entire workspace.

### Fix

Added `--exclude rustpix-python` flag to cargo bundle command:
```bash
cargo bundle --release --package rustpix-gui --exclude rustpix-python
```

### Impact

- This fixes the macOS .app bundle and DMG generation
- Requires version bump to v1.0.3 (v1.0.2 crates already published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)