### PR TITLE
chore: v1.0.4 - version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-02-04
+
+### Fixed
+
+- macOS app bundle: Use working-directory to build from rustpix-gui crate, avoiding workspace-level build that includes rustpix-python
+
 ## [1.0.3] - 2026-02-03
 
 ### Fixed
 
-- macOS app bundle: Excluded rustpix-python from build to fix linker errors
+- macOS app bundle: Excluded rustpix-python from build to fix linker errors (failed - invalid flag)
 
 ## [1.0.2] - 2026-02-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-algorithms"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "rayon",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "rayon",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "serde",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-gui"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "eframe",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-io"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "hdf5-metno",
  "memmap2",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-python"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "numpy",
  "pyo3",
@@ -3864,11 +3864,11 @@ dependencies = [
 
 [[package]]
 name = "rustpix-tools"
-version = "1.0.3"
+version = "1.0.4"
 
 [[package]]
 name = "rustpix-tpx"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["ORNL Neutron Imaging <neutronimaging@ornl.gov>"]
 license = "MIT"
@@ -30,10 +30,10 @@ categories = ["science", "data-structures", "parsing"]
 
 [workspace.dependencies]
 # Internal crates (version for crates.io, path for local dev)
-rustpix-core = { version = "1.0.3", path = "rustpix-core" }
-rustpix-tpx = { version = "1.0.3", path = "rustpix-tpx" }
-rustpix-algorithms = { version = "1.0.3", path = "rustpix-algorithms" }
-rustpix-io = { version = "1.0.3", path = "rustpix-io" }
+rustpix-core = { version = "1.0.4", path = "rustpix-core" }
+rustpix-tpx = { version = "1.0.4", path = "rustpix-tpx" }
+rustpix-algorithms = { version = "1.0.4", path = "rustpix-algorithms" }
+rustpix-io = { version = "1.0.4", path = "rustpix-io" }
 
 # Parallelism
 rayon = "1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustpix"
-version = "1.0.3"
+version = "1.0.4"
 description = "High-performance TPX3 pixel detector data processing for neutron imaging"
 authors = [{ name = "ORNL Neutron Imaging", email = "neutronimaging@ornl.gov" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Bump version to 1.0.4 after v1.0.3 release failed due to macOS app bundle build issue.

## Changes

- Version bumped to 1.0.4 in Cargo.toml and pyproject.toml
- CHANGELOG.md updated with v1.0.4 entry

## Release Notes

v1.0.4 includes the working fix for macOS app bundle build using `working-directory` approach (merged in #113).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)