### PR TITLE
feat: upgrade egui/eframe 0.29 → 0.33 (Issue #125)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,53 +20,53 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.16.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.9.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5393c75d4666f580f4cac0a968bc97c36076bb536a129f28210dac54ee127ed"
+checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "atspi-common",
  "serde",
  "thiserror 1.0.69",
- "zvariant 4.2.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.24.3"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12dc159d52233c43d9fe5415969433cbdd52c3d6e0df51bda7d447427b9986"
+checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
 dependencies = [
  "accesskit",
- "immutable-chunkmap",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.17.4"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc6c1ecd82053d127961ad80a8beaa6004fb851a3a5b96506d7a6bd462403f6"
+checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
+ "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "once_cell",
 ]
 
 [[package]]
 name = "accesskit_unix"
-version = "0.12.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7f5cf6165be10a54b2655fa2e0e12b2509f38ed6fc43e11c31fdb7ee6230bb"
+checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -77,28 +77,28 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "serde",
- "zbus 4.4.0",
+ "zbus",
 ]
 
 [[package]]
 name = "accesskit_windows"
-version = "0.23.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974e96c347384d9133427167fb8a58c340cb0496988dacceebdc1ed27071023b"
+checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "paste",
+ "hashbrown 0.15.5",
  "static_assertions",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.22.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea3522719f1c44564d03e9469a8e2f3a98b3a8a880bd66d0789c6b9c4a669dd"
+checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -170,7 +170,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -268,9 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
+ "image",
  "log",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
@@ -286,7 +289,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -350,7 +353,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus 5.12.0",
+ "zbus",
 ]
 
 [[package]]
@@ -468,7 +471,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -503,7 +506,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -514,9 +517,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -525,42 +528,41 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zbus 4.4.0",
+ "zbus",
  "zbus-lockstep",
  "zbus-lockstep-macros",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
 name = "atspi-connection"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
  "futures-lite",
- "zbus 4.4.0",
+ "zbus",
 ]
 
 [[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
- "zbus 4.4.0",
- "zvariant 4.2.0",
+ "zbus",
 ]
 
 [[package]]
@@ -614,24 +616,24 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -665,15 +667,6 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block2"
@@ -735,7 +728,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -827,12 +820,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -877,7 +864,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -906,10 +893,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -925,37 +913,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "combine"
@@ -1010,7 +967,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types",
+ "core-graphics-types 0.1.3",
  "foreign-types",
  "libc",
 ]
@@ -1027,21 +984,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
 name = "core2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1085,16 +1044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,16 +1054,6 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dispatch"
@@ -1142,7 +1081,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1177,9 +1116,9 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1187,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
+checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1198,7 +1137,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.14.2",
+ "glow",
  "glutin",
  "glutin-winit",
  "image",
@@ -1209,36 +1148,40 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "parking_lot",
  "percent-encoding",
+ "profiling",
  "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "winapi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.10.0",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
+checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1246,7 +1189,8 @@ dependencies = [
  "egui",
  "epaint",
  "log",
- "thiserror 1.0.69",
+ "profiling",
+ "thiserror 2.0.17",
  "type-map",
  "web-time",
  "wgpu",
@@ -1255,15 +1199,19 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
 dependencies = [
  "accesskit_winit",
- "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "profiling",
  "raw-window-handle",
  "smithay-clipboard",
  "web-time",
@@ -1273,30 +1221,31 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3c1f5cd8dfe2ade470a218696c66cf556fcfd701e7830fa2e9f4428292a2a1"
+checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
 dependencies = [
  "ahash",
  "egui",
  "enum-map",
  "log",
  "mime_guess2",
+ "profiling",
  "resvg",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
+checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
 dependencies = [
- "ahash",
  "bytemuck",
  "egui",
- "glow 0.14.2",
+ "glow",
  "log",
  "memoffset",
+ "profiling",
  "wasm-bindgen",
  "web-sys",
  "winit",
@@ -1304,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.29.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dca4871c15d51aadb79534dcf51a8189e5de3426ee7b465eb7db9a0a81ea67"
+checksum = "67fc9b427a837264e55381a5cade6e28fe83ac5b165a61b9c888548c732a9c95"
 dependencies = [
  "ahash",
  "egui",
@@ -1321,9 +1270,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
 dependencies = [
  "bytemuck",
 ]
@@ -1341,7 +1290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
- "serde",
 ]
 
 [[package]]
@@ -1352,7 +1300,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1373,7 +1321,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1401,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1414,13 +1362,14 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "profiling",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.29.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
+checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
 
 [[package]]
 name = "equator"
@@ -1439,7 +1388,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1463,6 +1412,15 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "event-listener"
@@ -1523,7 +1481,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1564,6 +1522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1545,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -1641,14 +1605,8 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -1665,22 +1623,11 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1690,18 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.2",
- "windows-link",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1739,21 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1768,7 +1692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.10.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -1792,7 +1716,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -1848,15 +1772,14 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1887,6 +1810,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1896,7 +1820,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1904,20 +1828,8 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 2.10.0",
- "com",
- "libc",
- "libloading",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1946,7 +1858,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -2151,24 +2063,15 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
-name = "immutable-chunkmap"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "indexmap"
@@ -2197,7 +2100,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -2242,7 +2145,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -2273,7 +2176,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
  "libc",
 ]
 
@@ -2306,11 +2209,13 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kurbo"
-version = "0.9.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -2342,8 +2247,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2471,13 +2382,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.10.0",
  "block",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types",
  "log",
  "objc",
@@ -2524,23 +2435,28 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "22.1.0"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.10.0",
- "cfg_aliases 0.1.1",
+ "cfg-if",
+ "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
+ "num-traits",
+ "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
+ "thiserror 2.0.17",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2567,7 +2483,7 @@ dependencies = [
  "bitflags 2.10.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2578,15 +2494,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2605,26 +2512,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -2686,7 +2580,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -2716,6 +2610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2737,7 +2632,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3058,6 +2953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,7 +3006,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3153,7 +3057,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
  "unicase",
 ]
 
@@ -3163,7 +3067,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
  "unicase",
 ]
 
@@ -3190,7 +3094,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3362,7 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3421,7 +3325,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3434,7 +3338,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3454,21 +3358,21 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3492,8 +3396,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3503,18 +3405,8 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3532,9 +3424,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -3542,8 +3431,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rav1e"
@@ -3573,7 +3468,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.17",
  "v_frame",
@@ -3626,12 +3521,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "rctree"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
 
 [[package]]
 name = "redox_syscall"
@@ -3688,9 +3577,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "resvg"
-version = "0.37.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadccb3d99a9efb8e5e00c16fbb732cbe400db2ec7fc004697ee7d97d86cf1f4"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
  "log",
  "pico-args",
@@ -3735,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-hash"
@@ -3779,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-algorithms"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "approx",
  "rayon",
@@ -3789,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "hdf5-metno",
@@ -3805,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "approx",
  "serde",
@@ -3814,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-gui"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "eframe",
@@ -3838,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-io"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "hdf5-metno",
  "memmap2",
@@ -3855,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "rustpix-python"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "hdf5-metno",
  "numpy",
@@ -3868,11 +3757,11 @@ dependencies = [
 
 [[package]]
 name = "rustpix-tools"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "rustpix-tpx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "approx",
  "rayon",
@@ -3956,7 +3845,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -3980,18 +3869,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "syn",
 ]
 
 [[package]]
@@ -4032,12 +3910,6 @@ checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -4176,23 +4048,12 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svgtypes"
-version = "0.13.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "siphasher",
 ]
 
 [[package]]
@@ -4214,7 +4075,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -4245,7 +4106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
@@ -4286,7 +4147,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -4297,7 +4158,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -4400,7 +4261,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -4426,12 +4287,6 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.1",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uds_windows"
@@ -4469,12 +4324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,46 +4349,24 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.37.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0a51b72ab80ca511d126b77feeeb4fb1e972764653e61feac30adc161a756"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
  "base64",
- "log",
- "pico-args",
- "usvg-parser",
- "usvg-tree",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg-parser"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd4e3c291f45d152929a31f0f6c819245e2921bfd01e7bd91201a9af39a2bdc"
-dependencies = [
  "data-url",
  "flate2",
  "imagesize",
  "kurbo",
  "log",
+ "pico-args",
  "roxmltree",
  "simplecss",
- "siphasher 0.3.11",
- "svgtypes",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-tree"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee3d202ebdb97a6215604b8f5b4d6ef9024efd623cf2e373a6416ba976ec7d3"
-dependencies = [
- "rctree",
+ "siphasher",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -4599,12 +4426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,7 +4479,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4850,16 +4671,21 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "22.1.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
+ "naga",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -4874,47 +4700,85 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "22.1.0"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
+ "bit-set",
  "bit-vec",
  "bitflags 2.10.0",
- "cfg_aliases 0.1.1",
+ "bytemuck",
+ "cfg_aliases",
  "document-features",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "22.0.0"
+name = "wgpu-core-deps-apple"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "27.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
+ "bit-set",
  "bitflags 2.10.0",
- "cfg_aliases 0.1.1",
- "core-graphics-types",
- "glow 0.13.1",
+ "block",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "core-graphics-types 0.2.0",
+ "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -4922,38 +4786,39 @@ dependencies = [
  "log",
  "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
+ "ndk-sys",
  "objc",
  "once_cell",
+ "ordered-float",
  "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
  "profiling",
+ "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "winapi",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "22.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.10.0",
+ "bytemuck",
  "js-sys",
+ "log",
+ "thiserror 2.0.17",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5007,6 +4872,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,11 +4908,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5036,7 +4947,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5047,14 +4969,41 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -5066,13 +5015,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5117,7 +5084,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5157,7 +5124,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5166,6 +5133,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5319,7 +5295,7 @@ dependencies = [
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -5429,16 +5405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,46 +5460,8 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.5",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5556,7 +5484,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.30.1",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -5565,46 +5493,33 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros 5.12.0",
- "zbus_names 4.2.0",
- "zvariant 5.8.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
 dependencies = [
  "zbus_xml",
- "zvariant 4.2.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
  "zbus-lockstep",
  "zbus_xml",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
- "zvariant_utils 2.1.0",
+ "zvariant",
 ]
 
 [[package]]
@@ -5616,46 +5531,33 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
- "zbus_names 4.2.0",
- "zvariant 5.8.0",
- "zvariant_utils 3.2.1",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "static_assertions",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
-dependencies = [
- "serde",
- "static_assertions",
  "winnow",
- "zvariant 5.8.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
 dependencies = [
- "quick-xml 0.30.0",
+ "quick-xml 0.38.4",
  "serde",
- "static_assertions",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -5675,7 +5577,7 @@ checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -5695,7 +5597,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
  "synstructure",
 ]
 
@@ -5729,7 +5631,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn",
 ]
 
 [[package]]
@@ -5773,78 +5675,41 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
  "winnow",
- "zvariant_derive 5.8.0",
- "zvariant_utils 3.2.1",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
- "zvariant_utils 2.1.0",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
- "zvariant_utils 3.2.1",
+ "syn",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.111",
+ "syn",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 authors = ["ORNL Neutron Imaging <neutronimaging@ornl.gov>"]
 license = "MIT"
@@ -30,10 +30,10 @@ categories = ["science", "data-structures", "parsing"]
 
 [workspace.dependencies]
 # Internal crates (version for crates.io, path for local dev)
-rustpix-core = { version = "1.1.1", path = "rustpix-core" }
-rustpix-tpx = { version = "1.1.1", path = "rustpix-tpx" }
-rustpix-algorithms = { version = "1.1.1", path = "rustpix-algorithms" }
-rustpix-io = { version = "1.1.1", path = "rustpix-io" }
+rustpix-core = { version = "1.1.2", path = "rustpix-core" }
+rustpix-tpx = { version = "1.1.2", path = "rustpix-tpx" }
+rustpix-algorithms = { version = "1.1.2", path = "rustpix-algorithms" }
+rustpix-io = { version = "1.1.2", path = "rustpix-io" }
 
 # Parallelism
 rayon = "1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustpix"
-version = "1.1.1"
+version = "1.1.2"
 description = "High-performance TPX3 pixel detector data processing for neutron imaging"
 authors = [{ name = "ORNL Neutron Imaging", email = "neutronimaging@ornl.gov" }]
 license = { file = "LICENSE" }
@@ -42,7 +42,7 @@ Issues = "https://github.com/ornlneutronimaging/rustpix/issues"
 arrow = ["pyarrow"]
 hdf5 = ["h5py"]
 io = ["pyarrow", "h5py"]
-gui = ["rustpix-gui==1.1.1"]
+gui = ["rustpix-gui==1.1.2"]
 
 [tool.maturin]
 manifest-path = "rustpix-python/Cargo.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ default = { features = [] }
 
 [tool.pixi.tasks]
 # Core tasks
-test = { cmd = "cargo test --workspace && python -c 'import rustpix; print(f\"rustpix imported successfully: {len(dir(rustpix))} symbols\")' && test -d tests && python -m pytest tests/ -v || echo 'No Python tests yet'", description = "Run all tests (Rust + Python)" }
+test = { cmd = "cargo test --workspace && python -c 'import rustpix; print(f\"rustpix imported successfully: {len(dir(rustpix))} symbols\")' && (test -d tests && python -m pytest tests/ -v || echo 'No Python tests yet')", depends-on = ["build-debug"], description = "Run all tests (Rust + Python)" }
 clippy = { cmd = "cargo clippy --workspace --all-targets --all-features", description = "Run clippy for all Rust crates/targets/features" }
 fmt = { cmd = "cargo fmt --all", description = "Format all Rust crates" }
 lint = { cmd = "cargo fmt --all && cargo clippy --workspace --all-targets --all-features", description = "Format and clippy all Rust crates/targets/features" }

--- a/rustpix-gui/Cargo.toml
+++ b/rustpix-gui/Cargo.toml
@@ -37,10 +37,10 @@ memmap2.workspace = true
 rayon.workspace = true
 
 # GUI
-eframe = "0.29"
-egui = "0.29"
-egui_plot = "0.29"
-egui_extras = { version = "0.29", features = ["svg"] }
+eframe = "0.33"
+egui = "0.33"
+egui_plot = "0.34"
+egui_extras = { version = "0.33", features = ["svg"] }
 rfd = "0.15"
 image = "0.25"
 tiff = "0.10"

--- a/rustpix-gui/pyproject.toml
+++ b/rustpix-gui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustpix-gui"
-version = "1.1.1"
+version = "1.1.2"
 description = "GUI application for rustpix pixel detector processing"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/rustpix-gui/src/app.rs
+++ b/rustpix-gui/src/app.rs
@@ -629,7 +629,8 @@ impl RustpixApp {
         let (disp_w, disp_h) = transform.display_size(width, height);
 
         let Some(counts) = counts else {
-            return egui::ColorImage::new([disp_w.max(1), disp_h.max(1)], egui::Color32::BLACK);
+            let pixel_count = disp_w.max(1) * disp_h.max(1);
+            return egui::ColorImage::new([disp_w.max(1), disp_h.max(1)], vec![egui::Color32::BLACK; pixel_count]);
         };
         generate_histogram_image_transformed(
             counts,

--- a/rustpix-gui/src/app.rs
+++ b/rustpix-gui/src/app.rs
@@ -630,7 +630,10 @@ impl RustpixApp {
 
         let Some(counts) = counts else {
             let pixel_count = disp_w.max(1) * disp_h.max(1);
-            return egui::ColorImage::new([disp_w.max(1), disp_h.max(1)], vec![egui::Color32::BLACK; pixel_count]);
+            return egui::ColorImage::new(
+                [disp_w.max(1), disp_h.max(1)],
+                vec![egui::Color32::BLACK; pixel_count],
+            );
         };
         generate_histogram_image_transformed(
             counts,

--- a/rustpix-gui/src/main.rs
+++ b/rustpix-gui/src/main.rs
@@ -36,10 +36,16 @@ fn main() -> eframe::Result<()> {
     )
 }
 
+#[allow(clippy::default_trait_access)]
 fn load_app_icon() -> Option<egui::IconData> {
     let bytes = include_bytes!("../assets/icons/app-icon.svg");
+    let size_hint = egui::SizeHint::Size {
+        width: 256,
+        height: 256,
+        maintain_aspect_ratio: true,
+    };
     let image =
-        egui_extras::image::load_svg_bytes_with_size(bytes, Some(egui::SizeHint::Size(256, 256)))
+        egui_extras::image::load_svg_bytes_with_size(bytes, size_hint, &Default::default())
             .ok()?;
     let [width, height] = image.size;
     let width = u32::try_from(width).ok()?;

--- a/rustpix-gui/src/main.rs
+++ b/rustpix-gui/src/main.rs
@@ -36,7 +36,6 @@ fn main() -> eframe::Result<()> {
     )
 }
 
-#[allow(clippy::default_trait_access)]
 fn load_app_icon() -> Option<egui::IconData> {
     let bytes = include_bytes!("../assets/icons/app-icon.svg");
     let size_hint = egui::SizeHint::Size {
@@ -44,8 +43,11 @@ fn load_app_icon() -> Option<egui::IconData> {
         height: 256,
         maintain_aspect_ratio: true,
     };
+    // Options type is resvg::usvg::Options (transitive dep, not directly nameable)
+    #[allow(clippy::default_trait_access)]
+    let svg_options = Default::default();
     let image =
-        egui_extras::image::load_svg_bytes_with_size(bytes, size_hint, &Default::default()).ok()?;
+        egui_extras::image::load_svg_bytes_with_size(bytes, size_hint, &svg_options).ok()?;
     let [width, height] = image.size;
     let width = u32::try_from(width).ok()?;
     let height = u32::try_from(height).ok()?;

--- a/rustpix-gui/src/main.rs
+++ b/rustpix-gui/src/main.rs
@@ -45,8 +45,7 @@ fn load_app_icon() -> Option<egui::IconData> {
         maintain_aspect_ratio: true,
     };
     let image =
-        egui_extras::image::load_svg_bytes_with_size(bytes, size_hint, &Default::default())
-            .ok()?;
+        egui_extras::image::load_svg_bytes_with_size(bytes, size_hint, &Default::default()).ok()?;
     let [width, height] = image.size;
     let width = u32::try_from(width).ok()?;
     let height = u32::try_from(height).ok()?;

--- a/rustpix-gui/src/ui/control_panel.rs
+++ b/rustpix-gui/src/ui/control_panel.rs
@@ -111,8 +111,9 @@ impl RustpixApp {
         } else {
             FontId::new(12.0, FontFamily::Monospace)
         };
-        let galley =
-            ui.painter().layout_no_wrap(status_text.clone(), status_font, status_color);
+        let galley = ui
+            .painter()
+            .layout_no_wrap(status_text.clone(), status_font, status_color);
         let text_width = galley.size().x;
         let text_y = status_rect.center().y - galley.size().y / 2.0;
         let painter = ui.painter().with_clip_rect(status_rect);
@@ -681,7 +682,8 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             };
-            ui.painter().rect_filled(header_rect, CornerRadius::ZERO, header_fill);
+            ui.painter()
+                .rect_filled(header_rect, CornerRadius::ZERO, header_fill);
 
             let text_pos = header_rect.left_center() + egui::vec2(16.0, 0.0);
             ui.painter().text(

--- a/rustpix-gui/src/ui/control_panel.rs
+++ b/rustpix-gui/src/ui/control_panel.rs
@@ -1,6 +1,6 @@
 //! Control panel (left sidebar) and top/bottom bars rendering.
 
-use eframe::egui::{self, Color32, FontFamily, FontId, Rect, Rounding, Stroke};
+use eframe::egui::{self, Color32, CornerRadius, FontFamily, FontId, Rect, Stroke, StrokeKind};
 use rfd::FileDialog;
 
 use super::theme::{accent, form_label, primary_button, ThemeColors};
@@ -35,13 +35,13 @@ impl RustpixApp {
 
         egui::TopBottomPanel::top("top_bar")
             .frame(
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(colors.bg_header)
                     .inner_margin(egui::Margin {
-                        left: 16.0,
-                        right: 16.0,
-                        top: 8.0,
-                        bottom: 8.0,
+                        left: 16,
+                        right: 16,
+                        top: 8,
+                        bottom: 8,
                     }),
             )
             .show(ctx, |ui| {
@@ -112,7 +112,7 @@ impl RustpixApp {
             FontId::new(12.0, FontFamily::Monospace)
         };
         let galley =
-            ui.fonts(|fonts| fonts.layout_no_wrap(status_text.clone(), status_font, status_color));
+            ui.painter().layout_no_wrap(status_text.clone(), status_font, status_color);
         let text_width = galley.size().x;
         let text_y = status_rect.center().y - galley.size().y / 2.0;
         let painter = ui.painter().with_clip_rect(status_rect);
@@ -208,9 +208,9 @@ impl RustpixApp {
     ) -> egui::Response {
         let image = Self::file_icon_image(icon, colors.text_primary)
             .fit_to_exact_size(egui::vec2(16.0, 16.0));
-        let btn = egui::ImageButton::new(image)
+        let btn = egui::Button::image(image)
             .frame(true)
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         let response = ui
             .add_enabled_ui(enabled, |ui| ui.add_sized(egui::vec2(30.0, 28.0), btn))
             .inner;
@@ -223,11 +223,11 @@ impl RustpixApp {
         let old_mode = self.ui_state.view_mode;
 
         // Container frame for the toggle group
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(colors.bg_dark)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::same(2.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::same(2))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     let colors = ThemeColors::from_ui(ui);
@@ -249,7 +249,7 @@ impl RustpixApp {
                             Color32::TRANSPARENT
                         })
                         .stroke(Stroke::NONE)
-                        .rounding(Rounding::same(3.0))
+                        .corner_radius(CornerRadius::same(3))
                         .min_size(egui::vec2(70.0, 0.0));
 
                     if ui.add(hits_btn).clicked() {
@@ -276,7 +276,7 @@ impl RustpixApp {
                         Color32::TRANSPARENT
                     })
                     .stroke(Stroke::NONE)
-                    .rounding(Rounding::same(3.0))
+                    .corner_radius(CornerRadius::same(3))
                     .min_size(egui::vec2(90.0, 0.0));
 
                     if ui.add_enabled(neutrons_enabled, neutrons_btn).clicked() {
@@ -297,13 +297,13 @@ impl RustpixApp {
 
         egui::TopBottomPanel::bottom("status_bar")
             .frame(
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(colors.bg_header)
                     .inner_margin(egui::Margin {
-                        left: 16.0,
-                        right: 16.0,
-                        top: 6.0,
-                        bottom: 6.0,
+                        left: 16,
+                        right: 16,
+                        top: 6,
+                        bottom: 6,
                     }),
             )
             .show(ctx, |ui| {
@@ -514,11 +514,11 @@ impl RustpixApp {
             "Cache hits in RAM (enables rebuild + HDF5 export). Higher memory, slower load.";
         let stream_tooltip = "Stream only (faster load, lower memory). Rebuild/export disabled.";
 
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(colors.bg_dark)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::same(2.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::same(2))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing = egui::vec2(2.0, 0.0);
@@ -530,7 +530,7 @@ impl RustpixApp {
                             Color32::TRANSPARENT
                         })
                         .stroke(Stroke::NONE)
-                        .rounding(Rounding::same(3.0))
+                        .corner_radius(CornerRadius::same(3))
                         .min_size(egui::vec2(28.0, 0.0));
 
                     if ui.add(cache_btn).on_hover_text(cache_tooltip).clicked() {
@@ -544,7 +544,7 @@ impl RustpixApp {
                             accent::BLUE
                         })
                         .stroke(Stroke::NONE)
-                        .rounding(Rounding::same(3.0))
+                        .corner_radius(CornerRadius::same(3))
                         .min_size(egui::vec2(28.0, 0.0));
 
                     if ui.add(stream_btn).on_hover_text(stream_tooltip).clicked() {
@@ -561,7 +561,7 @@ impl RustpixApp {
         egui::SidePanel::left("ctrl")
             .default_width(240.0)
             .frame(
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(colors.bg_panel)
                     .inner_margin(egui::Margin::ZERO),
             )
@@ -681,7 +681,7 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             };
-            ui.painter().rect_filled(header_rect, 0.0, header_fill);
+            ui.painter().rect_filled(header_rect, CornerRadius::ZERO, header_fill);
 
             let text_pos = header_rect.left_center() + egui::vec2(16.0, 0.0);
             ui.painter().text(
@@ -700,10 +700,11 @@ impl RustpixApp {
                 };
                 ui.painter().rect_stroke(
                     rect,
-                    Rounding::same(3.0),
+                    CornerRadius::same(3),
                     Stroke::new(1.0, colors.border_light),
+                    StrokeKind::Inside,
                 );
-                ui.painter().rect_filled(rect, Rounding::same(3.0), fill);
+                ui.painter().rect_filled(rect, CornerRadius::same(3), fill);
                 ui.painter().text(
                     rect.center(),
                     egui::Align2::CENTER_CENTER,
@@ -732,12 +733,12 @@ impl RustpixApp {
 
             // Content
             if is_open {
-                egui::Frame::none()
+                egui::Frame::new()
                     .inner_margin(egui::Margin {
-                        left: 16.0,
-                        right: 16.0,
-                        top: 12.0,
-                        bottom: 16.0,
+                        left: 16,
+                        right: 16,
+                        top: 12,
+                        bottom: 16,
                     })
                     .show(ui, |ui| {
                         content(self, ui);
@@ -758,8 +759,8 @@ impl RustpixApp {
         let is_busy = self.processing.is_loading || self.processing.is_processing;
 
         if is_busy {
-            egui::Frame::none()
-                .inner_margin(egui::Margin::symmetric(12.0, 8.0))
+            egui::Frame::new()
+                .inner_margin(egui::Margin::symmetric(12, 8))
                 .show(ui, |ui| {
                     ui.add(
                         egui::ProgressBar::new(self.processing.progress)
@@ -868,7 +869,7 @@ impl RustpixApp {
                     egui::Button::new("⚙")
                         .fill(Color32::TRANSPARENT)
                         .stroke(Stroke::new(1.0, colors.border_light))
-                        .rounding(Rounding::same(4.0)),
+                        .corner_radius(CornerRadius::same(4)),
                 )
                 .on_hover_text("Algorithm parameters")
                 .clicked()
@@ -881,11 +882,11 @@ impl RustpixApp {
 
     fn render_clustering_params(&mut self, ui: &mut egui::Ui, colors: &ThemeColors) {
         ui.add_space(8.0);
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(colors.bg_header)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::same(12.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::same(12))
             .show(ui, |ui| {
                 self.render_detector_profile_controls(ui);
                 ui.add_space(6.0);
@@ -947,10 +948,9 @@ impl RustpixApp {
                                 custom_label,
                             );
                         } else {
-                            ui.add_enabled(
-                                false,
-                                egui::SelectableLabel::new(false, "Custom (load...)"),
-                            );
+                            ui.add_enabled_ui(false, |ui| {
+                                let _ = ui.selectable_label(false, "Custom (load...)");
+                            });
                         }
                         if kind != self.detector_profile.kind {
                             self.detector_profile.kind = kind;
@@ -1092,7 +1092,7 @@ impl RustpixApp {
                             egui::Button::new("?")
                                 .fill(Color32::TRANSPARENT)
                                 .stroke(Stroke::new(1.0, colors.border_light))
-                                .rounding(Rounding::same(4.0)),
+                                .corner_radius(CornerRadius::same(4)),
                         )
                         .on_hover_text(
                             "Affine transform per chip:\n\
@@ -1651,7 +1651,7 @@ x,y are local chip coordinates (pixels).",
                 let gear = Self::file_icon_image(FileToolbarIcon::Gear, colors.text_muted)
                     .fit_to_exact_size(egui::vec2(14.0, 14.0));
                 if ui
-                    .add(egui::ImageButton::new(gear).frame(true))
+                    .add(egui::Button::image(gear).frame(true))
                     .on_hover_text("Pixel mask settings")
                     .clicked()
                 {
@@ -2325,7 +2325,7 @@ x,y are local chip coordinates (pixels).",
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let gear = Self::file_icon_image(FileToolbarIcon::Gear, colors.text_muted);
                 if ui
-                    .add(egui::ImageButton::new(gear).frame(true))
+                    .add(egui::Button::image(gear).frame(true))
                     .on_hover_text("Advanced export options")
                     .clicked()
                 {

--- a/rustpix-gui/src/ui/main_view.rs
+++ b/rustpix-gui/src/ui/main_view.rs
@@ -470,11 +470,17 @@ impl RustpixApp {
             );
             let _ = ui.allocate_rect(rect, egui::Sense::hover());
 
-            ui.painter().rect_filled(rect, CornerRadius::same(4), colors.bg_panel);
             ui.painter()
-                .rect_stroke(rect, CornerRadius::same(4), Stroke::new(1.0, colors.border), StrokeKind::Inside);
+                .rect_filled(rect, CornerRadius::same(4), colors.bg_panel);
+            ui.painter().rect_stroke(
+                rect,
+                CornerRadius::same(4),
+                Stroke::new(1.0, colors.border),
+                StrokeKind::Inside,
+            );
 
-            let inner_rect = rect.shrink2(egui::vec2(f32::from(margin.left), f32::from(margin.top)));
+            let inner_rect =
+                rect.shrink2(egui::vec2(f32::from(margin.left), f32::from(margin.top)));
             let mut slicer_ui = ui.new_child(
                 egui::UiBuilder::new()
                     .max_rect(inner_rect)
@@ -1381,7 +1387,12 @@ impl RustpixApp {
             }
 
             // Border
-            painter.rect_stroke(rect.1, CornerRadius::ZERO, Stroke::new(1.0, colors.border), StrokeKind::Inside);
+            painter.rect_stroke(
+                rect.1,
+                CornerRadius::ZERO,
+                Stroke::new(1.0, colors.border),
+                StrokeKind::Inside,
+            );
 
             // "0" label at bottom
             ui.add_space(4.0);
@@ -1433,29 +1444,33 @@ impl RustpixApp {
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
             .corner_radius(CornerRadius::same(4));
-        let menu_response = egui::containers::menu::MenuButton::from_button(menu_button).ui(ui, |ui| {
-            ui.horizontal(|ui| {
-                Self::paint_roi_icon_in_ui(ui, RoiToolbarIcon::Rectangle, colors.text_muted);
-                if ui
-                    .selectable_label(
-                        self.roi_state.mode == RoiSelectionMode::Rectangle,
-                        "Rectangle",
-                    )
-                    .clicked()
-                {
-                    selection_mode = RoiSelectionMode::Rectangle;
-                }
+        let menu_response =
+            egui::containers::menu::MenuButton::from_button(menu_button).ui(ui, |ui| {
+                ui.horizontal(|ui| {
+                    Self::paint_roi_icon_in_ui(ui, RoiToolbarIcon::Rectangle, colors.text_muted);
+                    if ui
+                        .selectable_label(
+                            self.roi_state.mode == RoiSelectionMode::Rectangle,
+                            "Rectangle",
+                        )
+                        .clicked()
+                    {
+                        selection_mode = RoiSelectionMode::Rectangle;
+                    }
+                });
+                ui.horizontal(|ui| {
+                    Self::paint_roi_icon_in_ui(ui, RoiToolbarIcon::Polygon, colors.text_muted);
+                    if ui
+                        .selectable_label(
+                            self.roi_state.mode == RoiSelectionMode::Polygon,
+                            "Polygon",
+                        )
+                        .clicked()
+                    {
+                        selection_mode = RoiSelectionMode::Polygon;
+                    }
+                });
             });
-            ui.horizontal(|ui| {
-                Self::paint_roi_icon_in_ui(ui, RoiToolbarIcon::Polygon, colors.text_muted);
-                if ui
-                    .selectable_label(self.roi_state.mode == RoiSelectionMode::Polygon, "Polygon")
-                    .clicked()
-                {
-                    selection_mode = RoiSelectionMode::Polygon;
-                }
-            });
-        });
         let icon_rect = menu_response.0.rect.shrink2(egui::vec2(4.0, 4.0));
         let icon_rect = Rect::from_min_max(
             icon_rect.min,
@@ -1492,12 +1507,13 @@ impl RustpixApp {
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
             .corner_radius(CornerRadius::same(4));
-        let gear_response = egui::containers::menu::MenuButton::from_button(gear_button).ui(ui, |ui| {
-            ui.checkbox(
-                &mut self.roi_state.debounce_updates,
-                "Debounce spectrum updates",
-            );
-        });
+        let gear_response =
+            egui::containers::menu::MenuButton::from_button(gear_button).ui(ui, |ui| {
+                ui.checkbox(
+                    &mut self.roi_state.debounce_updates,
+                    "Debounce spectrum updates",
+                );
+            });
         let image = Self::roi_icon_image(RoiToolbarIcon::Gear, colors.text_muted);
         image.paint_at(ui, gear_response.0.rect.shrink(4.0));
         gear_response.0.on_hover_text("ROI settings");
@@ -2161,10 +2177,8 @@ impl RustpixApp {
             }
 
             for (name, color, points) in &data.lines {
-                plot_ui.line(
-                    Line::new(name.as_str(), PlotPoints::new(points.clone()))
-                        .color(*color),
-                );
+                plot_ui
+                    .line(Line::new(name.as_str(), PlotPoints::new(points.clone())).color(*color));
             }
 
             let response = plot_ui.response().clone();

--- a/rustpix-gui/src/ui/main_view.rs
+++ b/rustpix-gui/src/ui/main_view.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 
-use eframe::egui::{self, Color32, LayerId, Order, Pos2, Rect, Rounding, Stroke, Vec2, Vec2b};
+use eframe::egui::{
+    self, Color32, CornerRadius, LayerId, Order, Pos2, Rect, Stroke, StrokeKind, Vec2, Vec2b,
+};
 use egui_plot::{
     Line, MarkerShape, Plot, PlotBounds, PlotImage, PlotPoint, PlotPoints, Points, VLine,
 };
@@ -192,9 +194,9 @@ struct SpectrumExportGeometry {
     label_color: Rgba<u8>,
 }
 
-struct HistogramDragContext<'a> {
+struct HistogramDragContext<'a, 'b> {
     ctx: &'a egui::Context,
-    plot_ui: &'a mut egui_plot::PlotUi,
+    plot_ui: &'a mut egui_plot::PlotUi<'b>,
     response: &'a egui::Response,
     pointer_pos: Option<PlotPoint>,
     handle_radius: f64,
@@ -361,9 +363,9 @@ impl RustpixApp {
     ) {
         egui::CentralPanel::default()
             .frame(
-                egui::Frame::none()
+                egui::Frame::new()
                     .fill(colors.bg_dark)
-                    .inner_margin(egui::Margin::same(16.0)),
+                    .inner_margin(egui::Margin::same(16)),
             )
             .show(ctx, |ui| {
                 let layout = self.central_panel_layout(ui, inputs);
@@ -455,9 +457,9 @@ impl RustpixApp {
         if inputs.visibility.slicer_enabled && inputs.n_bins > 0 {
             let colors = ThemeColors::from_ui(ui);
             ui.add_space(8.0);
-            let margin = egui::Margin::symmetric(16.0, 12.0);
+            let margin = egui::Margin::symmetric(16, 12);
             let content_height = ui.spacing().interact_size.y.max(20.0);
-            let frame_height = content_height + margin.top + margin.bottom;
+            let frame_height = content_height + f32::from(margin.top) + f32::from(margin.bottom);
 
             let left = ui.max_rect().left();
             let right = ui.max_rect().right();
@@ -468,11 +470,11 @@ impl RustpixApp {
             );
             let _ = ui.allocate_rect(rect, egui::Sense::hover());
 
-            ui.painter().rect_filled(rect, 4.0, colors.bg_panel);
+            ui.painter().rect_filled(rect, CornerRadius::same(4), colors.bg_panel);
             ui.painter()
-                .rect_stroke(rect, 4.0, Stroke::new(1.0, colors.border));
+                .rect_stroke(rect, CornerRadius::same(4), Stroke::new(1.0, colors.border), StrokeKind::Inside);
 
-            let inner_rect = rect.shrink2(egui::vec2(margin.left, margin.top));
+            let inner_rect = rect.shrink2(egui::vec2(f32::from(margin.left), f32::from(margin.top)));
             let mut slicer_ui = ui.new_child(
                 egui::UiBuilder::new()
                     .max_rect(inner_rect)
@@ -589,7 +591,7 @@ impl RustpixApp {
                 .min_size(egui::vec2(0.0, 28.0))
                 .fill(Color32::TRANSPARENT)
                 .stroke(Stroke::new(1.0, colors.border_light))
-                .rounding(Rounding::same(4.0));
+                .corner_radius(CornerRadius::same(4));
 
                 if ui
                     .add(reset_btn)
@@ -626,7 +628,7 @@ impl RustpixApp {
                     Color32::TRANSPARENT
                 })
                 .stroke(Stroke::new(1.0, colors.border_light))
-                .rounding(Rounding::same(4.0));
+                .corner_radius(CornerRadius::same(4));
 
                 if ui.add(grid_btn).on_hover_text("Toggle grid").clicked() {
                     self.ui_state.histogram_view.show_grid =
@@ -700,7 +702,7 @@ impl RustpixApp {
                 Color32::TRANSPARENT
             })
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         ui.add(btn)
     }
 
@@ -806,10 +808,10 @@ impl RustpixApp {
         } else {
             Color32::from_rgb(0xe8, 0xe8, 0xe8)
         };
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(no_data_bg)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
+            .corner_radius(CornerRadius::same(4))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.centered_and_justified(|ui| {
@@ -937,6 +939,7 @@ impl RustpixApp {
         geometry: &HistogramGeometry,
     ) {
         plot_ui.image(PlotImage::new(
+            "histogram",
             tex_id,
             PlotPoint::new(geometry.half_x, geometry.half_y),
             [geometry.data_width_f32, geometry.data_height_f32],
@@ -964,7 +967,7 @@ impl RustpixApp {
                             .map(|(x, y)| [x, y])
                             .collect()
                     };
-                    let hot_points = Points::new(PlotPoints::new(hot_points))
+                    let hot_points = Points::new("hot_pixels", PlotPoints::new(hot_points))
                         .shape(MarkerShape::Square)
                         .radius(2.0)
                         .color(accent::RED)
@@ -1143,7 +1146,7 @@ impl RustpixApp {
         }
     }
 
-    fn handle_histogram_roi_drag(&mut self, drag: &mut HistogramDragContext<'_>) {
+    fn handle_histogram_roi_drag(&mut self, drag: &mut HistogramDragContext<'_, '_>) {
         if drag.response.drag_started() {
             if let Some(pos) = drag.pointer_pos {
                 if let Some((roi_id, index)) =
@@ -1287,17 +1290,17 @@ impl RustpixApp {
 
         response.context_menu(|ui| {
             if suppress_context_menu {
-                ui.close_menu();
+                ui.close();
                 return;
             }
             if let Some(target) = self.roi_state.context_menu_target() {
                 if ui.button("Edit").clicked() {
                     self.roi_state.set_edit_mode(target, true);
-                    ui.close_menu();
+                    ui.close();
                 }
                 if ui.button("Delete").clicked() {
                     self.roi_state.delete_id(target);
-                    ui.close_menu();
+                    ui.close();
                 }
             } else {
                 ui.label("No ROI");
@@ -1332,13 +1335,14 @@ impl RustpixApp {
             .with_clip_rect(response.rect);
         painter.rect_filled(
             rect,
-            Rounding::same(2.0),
+            CornerRadius::same(2),
             Color32::from_rgba_unmultiplied(58, 130, 246, 32),
         );
         painter.rect_stroke(
             rect,
-            Rounding::same(2.0),
+            CornerRadius::same(2),
             Stroke::new(1.0, Color32::from_rgb(58, 130, 246)),
+            StrokeKind::Inside,
         );
     }
 
@@ -1372,13 +1376,13 @@ impl RustpixApp {
                         egui::pos2(rect.1.left(), y_start),
                         egui::vec2(rect.1.width(), step_height + 1.0),
                     ),
-                    0.0,
+                    CornerRadius::ZERO,
                     color,
                 );
             }
 
             // Border
-            painter.rect_stroke(rect.1, Rounding::ZERO, Stroke::new(1.0, colors.border));
+            painter.rect_stroke(rect.1, CornerRadius::ZERO, Stroke::new(1.0, colors.border), StrokeKind::Inside);
 
             // "0" label at bottom
             ui.add_space(4.0);
@@ -1392,10 +1396,10 @@ impl RustpixApp {
     /// Render ROI tool group controls.
     fn render_roi_toolbar(&mut self, ui: &mut egui::Ui) {
         let colors = ThemeColors::from_ui(ui);
-        egui::Frame::none()
+        egui::Frame::new()
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::symmetric(4.0, 2.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::symmetric(4, 2))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     let selection_mode = self.render_roi_mode_menu(ui, &colors);
@@ -1429,8 +1433,8 @@ impl RustpixApp {
             .min_size(egui::vec2(34.0, 22.0))
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
-        let menu_response = egui::menu::menu_custom_button(ui, menu_button, |ui| {
+            .corner_radius(CornerRadius::same(4));
+        let menu_response = egui::containers::menu::MenuButton::from_button(menu_button).ui(ui, |ui| {
             ui.horizontal(|ui| {
                 Self::paint_roi_icon_in_ui(ui, RoiToolbarIcon::Rectangle, colors.text_muted);
                 if ui
@@ -1453,7 +1457,7 @@ impl RustpixApp {
                 }
             });
         });
-        let icon_rect = menu_response.response.rect.shrink2(egui::vec2(4.0, 4.0));
+        let icon_rect = menu_response.0.rect.shrink2(egui::vec2(4.0, 4.0));
         let icon_rect = Rect::from_min_max(
             icon_rect.min,
             Pos2::new(icon_rect.center().x + 2.0, icon_rect.max.y),
@@ -1466,7 +1470,7 @@ impl RustpixApp {
             colors.text_muted,
         );
         image.paint_at(ui, icon_rect);
-        Self::paint_dropdown_caret(ui.painter(), menu_response.response.rect, colors.text_muted);
+        Self::paint_dropdown_caret(ui.painter(), menu_response.0.rect, colors.text_muted);
         selection_mode
     }
 
@@ -1488,16 +1492,16 @@ impl RustpixApp {
             .min_size(egui::vec2(28.0, 22.0))
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
-        let gear_response = egui::menu::menu_custom_button(ui, gear_button, |ui| {
+            .corner_radius(CornerRadius::same(4));
+        let gear_response = egui::containers::menu::MenuButton::from_button(gear_button).ui(ui, |ui| {
             ui.checkbox(
                 &mut self.roi_state.debounce_updates,
                 "Debounce spectrum updates",
             );
         });
         let image = Self::roi_icon_image(RoiToolbarIcon::Gear, colors.text_muted);
-        image.paint_at(ui, gear_response.response.rect.shrink(4.0));
-        gear_response.response.on_hover_text("ROI settings");
+        image.paint_at(ui, gear_response.0.rect.shrink(4.0));
+        gear_response.0.on_hover_text("ROI settings");
     }
 
     fn render_roi_help_button(&mut self, ui: &mut egui::Ui, colors: &ThemeColors) {
@@ -1505,7 +1509,7 @@ impl RustpixApp {
             .min_size(egui::vec2(24.0, 22.0))
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         let response = ui.add(help_button);
         if response.clicked() {
             self.ui_state.panel_popups.show_roi_help = !self.ui_state.panel_popups.show_roi_help;
@@ -1614,11 +1618,11 @@ impl RustpixApp {
         has_visible_spectrum: bool,
     ) -> SpectrumToolbarActions {
         let mut actions = SpectrumToolbarActions::default();
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(colors.bg_panel)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::symmetric(12.0, 8.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::symmetric(12, 8))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     let colors = ThemeColors::from_ui(ui);
@@ -1670,13 +1674,13 @@ impl RustpixApp {
                 }
 
                 if ui
-                    .add_enabled(
-                        energy_available,
-                        egui::SelectableLabel::new(
+                    .add_enabled_ui(energy_available, |ui| {
+                        ui.selectable_label(
                             self.ui_state.spectrum_x_axis == SpectrumXAxis::EnergyEv,
                             SpectrumXAxis::EnergyEv.to_string(),
-                        ),
-                    )
+                        )
+                    })
+                    .inner
                     .on_hover_text(if energy_available {
                         "Energy axis"
                     } else {
@@ -1699,7 +1703,7 @@ impl RustpixApp {
                 egui::Button::new("⚙")
                     .fill(Color32::TRANSPARENT)
                     .stroke(Stroke::new(1.0, colors.border_light))
-                    .rounding(Rounding::same(4.0)),
+                    .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Spectrum settings")
             .clicked()
@@ -1718,7 +1722,7 @@ impl RustpixApp {
                 Color32::TRANSPARENT
             })
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         let data_response = ui.add(data_button);
         let data_icon = Self::roi_icon_image(RoiToolbarIcon::Data, colors.text_muted);
         data_icon.paint_at(ui, data_response.rect.shrink(4.0));
@@ -1741,7 +1745,7 @@ impl RustpixApp {
         )
         .fill(Color32::TRANSPARENT)
         .stroke(Stroke::new(1.0, colors.border_light))
-        .rounding(Rounding::same(4.0));
+        .corner_radius(CornerRadius::same(4));
         if ui.add(range_btn).clicked() {
             let opening = !self.ui_state.panel_popups.show_spectrum_range;
             self.ui_state.panel_popups.show_spectrum_range = opening;
@@ -1760,7 +1764,7 @@ impl RustpixApp {
                 Color32::TRANSPARENT
             })
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         if ui.add(help_button).on_hover_text("Spectrum help").clicked() {
             self.ui_state.panel_popups.show_spectrum_help =
                 !self.ui_state.panel_popups.show_spectrum_help;
@@ -1782,7 +1786,7 @@ impl RustpixApp {
         )
         .fill(Color32::TRANSPARENT)
         .stroke(Stroke::new(1.0, colors.border_light))
-        .rounding(Rounding::same(4.0));
+        .corner_radius(CornerRadius::same(4));
         if ui
             .add_enabled(has_full_spectrum, png_btn)
             .on_hover_text("Export spectrum as PNG")
@@ -1798,7 +1802,7 @@ impl RustpixApp {
         )
         .fill(Color32::TRANSPARENT)
         .stroke(Stroke::new(1.0, colors.border_light))
-        .rounding(Rounding::same(4.0));
+        .corner_radius(CornerRadius::same(4));
         if ui
             .add_enabled(has_visible_spectrum, csv_btn)
             .on_hover_text("Export spectrum as CSV")
@@ -1826,7 +1830,7 @@ impl RustpixApp {
                     )
                     .fill(Color32::TRANSPARENT)
                     .stroke(Stroke::new(1.0, colors.border_light))
-                    .rounding(Rounding::same(4.0)),
+                    .corner_radius(CornerRadius::same(4)),
                 )
                 .on_hover_text("Reset spectrum view (or double-click)")
                 .clicked()
@@ -1869,7 +1873,7 @@ impl RustpixApp {
         let button = egui::Button::new(egui::RichText::new(label).size(10.0).color(text_color))
             .fill(fill)
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         ui.add(button).clicked()
     }
 
@@ -2159,9 +2163,8 @@ impl RustpixApp {
 
             for (name, color, points) in &data.lines {
                 plot_ui.line(
-                    Line::new(PlotPoints::new(points.clone()))
-                        .color(*color)
-                        .name(name.as_str()),
+                    Line::new(name.as_str(), PlotPoints::new(points.clone()))
+                        .color(*color),
                 );
             }
 
@@ -2269,11 +2272,10 @@ impl RustpixApp {
                     }
                 }
                 plot_ui.vline(
-                    VLine::new(slice_x)
+                    VLine::new(format!("Slice {}", inputs.current_tof_bin + 1), slice_x)
                         .color(accent::RED)
                         .width(1.0)
-                        .style(egui_plot::LineStyle::Dashed { length: 4.0 })
-                        .name(format!("Slice {}", inputs.current_tof_bin + 1)),
+                        .style(egui_plot::LineStyle::Dashed { length: 4.0 }),
                 );
             }
         }
@@ -2374,11 +2376,11 @@ impl RustpixApp {
         } else {
             Color32::from_rgb(0xe8, 0xe8, 0xe8)
         };
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(no_data_bg)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::same(16.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::same(16))
             .show(ui, |ui| {
                 let colors = ThemeColors::from_ui(ui);
                 ui.set_min_height(140.0);
@@ -2537,7 +2539,7 @@ impl RustpixApp {
                             .tint(colors.text_muted)
                             .fit_to_exact_size(egui::vec2(12.0, 12.0));
                     if ui
-                        .add(egui::ImageButton::new(rename_icon).frame(true))
+                        .add(egui::Button::image(rename_icon).frame(true))
                         .on_hover_text("Rename ROI")
                         .clicked()
                     {
@@ -2726,11 +2728,11 @@ impl RustpixApp {
 
     fn render_spectrum_legend(ui: &mut egui::Ui, items: &[(String, Color32)]) {
         let colors = ThemeColors::from_ui(ui);
-        egui::Frame::none()
+        egui::Frame::new()
             .fill(colors.bg_panel)
             .stroke(Stroke::new(1.0, colors.border))
-            .rounding(Rounding::same(4.0))
-            .inner_margin(egui::Margin::symmetric(10.0, 6.0))
+            .corner_radius(CornerRadius::same(4))
+            .inner_margin(egui::Margin::symmetric(10, 6))
             .show(ui, |ui| {
                 ui.horizontal_wrapped(|ui| {
                     ui.label(
@@ -2818,7 +2820,7 @@ impl RustpixApp {
                 Color32::TRANSPARENT
             })
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         let response = ui.add(button);
         let image = Self::zoom_icon_image(icon, tint);
         image.paint_at(ui, response.rect.shrink(5.0));
@@ -2852,7 +2854,7 @@ impl RustpixApp {
         move |ui: &mut egui::Ui| {
             let (rect, response) =
                 ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
-            ui.painter().rect_filled(rect, Rounding::same(2.0), color);
+            ui.painter().rect_filled(rect, CornerRadius::same(2), color);
             response
         }
     }
@@ -2863,7 +2865,7 @@ impl RustpixApp {
             .min_size(egui::vec2(28.0, 22.0))
             .fill(Color32::TRANSPARENT)
             .stroke(Stroke::new(1.0, colors.border_light))
-            .rounding(Rounding::same(4.0));
+            .corner_radius(CornerRadius::same(4));
         let response = ui.add(button);
         let image = Self::roi_icon_image(icon, colors.text_muted);
         image.paint_at(ui, response.rect.shrink(4.0));

--- a/rustpix-gui/src/ui/main_view.rs
+++ b/rustpix-gui/src/ui/main_view.rs
@@ -721,7 +721,6 @@ impl RustpixApp {
 
         let mut plot = Plot::new(HISTOGRAM_PLOT_ID)
             .data_aspect(1.0)
-            .auto_bounds(Vec2b::new(false, false))
             .include_x(0.0)
             .include_x(inputs.data_width_f64)
             .include_y(0.0)

--- a/rustpix-gui/src/ui/theme.rs
+++ b/rustpix-gui/src/ui/theme.rs
@@ -3,7 +3,7 @@
 //! Provides light and dark themes with monospace fonts, following system preference.
 
 use eframe::egui::{
-    self, Color32, FontFamily, FontId, Rounding, Stroke, TextStyle, Theme, Visuals,
+    self, Color32, CornerRadius, FontFamily, FontId, Stroke, TextStyle, Theme, Visuals,
 };
 
 /// Color palette for the application (dark theme).
@@ -144,27 +144,27 @@ fn build_dark_visuals() -> Visuals {
     visuals.widgets.noninteractive.bg_fill = dark::BG_INPUT;
     visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, dark::TEXT_MUTED);
     visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, dark::BORDER);
-    visuals.widgets.noninteractive.rounding = Rounding::same(4.0);
+    visuals.widgets.noninteractive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.inactive.bg_fill = dark::BG_INPUT;
     visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
     visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, dark::BORDER_LIGHT);
-    visuals.widgets.inactive.rounding = Rounding::same(4.0);
+    visuals.widgets.inactive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.hovered.bg_fill = dark::BUTTON_HOVER;
     visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
     visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, accent::BLUE);
-    visuals.widgets.hovered.rounding = Rounding::same(4.0);
+    visuals.widgets.hovered.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.active.bg_fill = accent::BLUE;
     visuals.widgets.active.fg_stroke = Stroke::new(1.0, Color32::WHITE);
     visuals.widgets.active.bg_stroke = Stroke::new(1.0, accent::BLUE);
-    visuals.widgets.active.rounding = Rounding::same(4.0);
+    visuals.widgets.active.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.open.bg_fill = dark::BG_INPUT;
     visuals.widgets.open.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
     visuals.widgets.open.bg_stroke = Stroke::new(1.0, dark::BORDER_LIGHT);
-    visuals.widgets.open.rounding = Rounding::same(4.0);
+    visuals.widgets.open.corner_radius = CornerRadius::same(4);
 
     visuals.selection.bg_fill = accent::BLUE.gamma_multiply(0.3);
     visuals.selection.stroke = Stroke::new(1.0, accent::BLUE);
@@ -184,27 +184,27 @@ fn build_light_visuals() -> Visuals {
     visuals.widgets.noninteractive.bg_fill = light::BG_INPUT;
     visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, light::TEXT_MUTED);
     visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, light::BORDER);
-    visuals.widgets.noninteractive.rounding = Rounding::same(4.0);
+    visuals.widgets.noninteractive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.inactive.bg_fill = light::BG_INPUT;
     visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
     visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, light::BORDER_LIGHT);
-    visuals.widgets.inactive.rounding = Rounding::same(4.0);
+    visuals.widgets.inactive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.hovered.bg_fill = light::BUTTON_HOVER;
     visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
     visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, accent::BLUE);
-    visuals.widgets.hovered.rounding = Rounding::same(4.0);
+    visuals.widgets.hovered.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.active.bg_fill = accent::BLUE;
     visuals.widgets.active.fg_stroke = Stroke::new(1.0, Color32::WHITE);
     visuals.widgets.active.bg_stroke = Stroke::new(1.0, accent::BLUE);
-    visuals.widgets.active.rounding = Rounding::same(4.0);
+    visuals.widgets.active.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.open.bg_fill = light::BG_INPUT;
     visuals.widgets.open.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
     visuals.widgets.open.bg_stroke = Stroke::new(1.0, light::BORDER_LIGHT);
-    visuals.widgets.open.rounding = Rounding::same(4.0);
+    visuals.widgets.open.corner_radius = CornerRadius::same(4);
 
     visuals.selection.bg_fill = accent::BLUE.gamma_multiply(0.2);
     visuals.selection.stroke = Stroke::new(1.0, accent::BLUE);
@@ -241,7 +241,7 @@ fn configure_fonts_and_spacing(ctx: &egui::Context) {
 pub fn primary_button(text: &str) -> egui::Button<'_> {
     egui::Button::new(egui::RichText::new(text).color(Color32::WHITE))
         .fill(accent::BLUE)
-        .rounding(Rounding::same(4.0))
+        .corner_radius(CornerRadius::same(4))
 }
 
 /// Create a form label.

--- a/rustpix-gui/src/viewer/roi.rs
+++ b/rustpix-gui/src/viewer/roi.rs
@@ -591,10 +591,11 @@ impl RoiState {
 
     /// Render all ROIs to the plot.
     pub fn draw(&self, plot_ui: &mut PlotUi) {
-        for (i, roi) in self.rois.iter().enumerate() {
+        for roi in &self.rois {
             if !roi.visibility.visible {
                 continue;
             }
+            let rid = roi.id;
             let stroke_width = if roi.selection.selected { 2.0 } else { 1.0 };
             let stroke = Stroke::new(stroke_width, roi.color);
             let fill = roi_fill_color(roi.color);
@@ -603,7 +604,7 @@ impl RoiState {
                 if polygon_is_convex(vertices) {
                     let points = roi.plot_points();
                     plot_ui.polygon(
-                        Polygon::new(format!("roi_{i}_poly"), points)
+                        Polygon::new(format!("roi_{rid}_poly"), points)
                             .stroke(stroke)
                             .fill_color(fill),
                     );
@@ -612,7 +613,7 @@ impl RoiState {
                     if triangles.is_empty() {
                         let line_points = roi.closed_line_points();
                         plot_ui.line(
-                            Line::new(format!("roi_{i}_line"), PlotPoints::new(line_points))
+                            Line::new(format!("roi_{rid}_line"), PlotPoints::new(line_points))
                                 .color(roi.color)
                                 .width(stroke_width),
                         );
@@ -620,7 +621,7 @@ impl RoiState {
                         for (ti, tri) in triangles.iter().enumerate() {
                             plot_ui.polygon(
                                 Polygon::new(
-                                    format!("roi_{i}_tri_{ti}"),
+                                    format!("roi_{rid}_tri_{ti}"),
                                     vec![tri[0], tri[1], tri[2]],
                                 )
                                 .stroke(Stroke::new(0.0, Color32::TRANSPARENT))
@@ -629,7 +630,7 @@ impl RoiState {
                         }
                         let line_points = roi.closed_line_points();
                         plot_ui.line(
-                            Line::new(format!("roi_{i}_outline"), PlotPoints::new(line_points))
+                            Line::new(format!("roi_{rid}_outline"), PlotPoints::new(line_points))
                                 .color(roi.color)
                                 .width(stroke_width),
                         );
@@ -638,7 +639,7 @@ impl RoiState {
             } else {
                 let points = roi.plot_points();
                 plot_ui.polygon(
-                    Polygon::new(format!("roi_{i}_shape"), points)
+                    Polygon::new(format!("roi_{rid}_shape"), points)
                         .stroke(stroke)
                         .fill_color(fill),
                 );
@@ -646,7 +647,7 @@ impl RoiState {
 
             let label_pos = roi.label_position();
             plot_ui.text(
-                Text::new(format!("roi_{i}_label"), label_pos, roi.name.clone())
+                Text::new(format!("roi_{rid}_label"), label_pos, roi.name.clone())
                     .color(roi.color)
                     .anchor(Align2::LEFT_TOP),
             );
@@ -655,7 +656,7 @@ impl RoiState {
                 let handle_points = roi.handle_points();
                 if !handle_points.is_empty() {
                     plot_ui.points(
-                        Points::new(format!("roi_{i}_handles"), handle_points)
+                        Points::new(format!("roi_{rid}_handles"), handle_points)
                             .color(roi.color)
                             .shape(MarkerShape::Square)
                             .radius(3.0),

--- a/rustpix-gui/src/viewer/roi.rs
+++ b/rustpix-gui/src/viewer/roi.rs
@@ -591,7 +591,7 @@ impl RoiState {
 
     /// Render all ROIs to the plot.
     pub fn draw(&self, plot_ui: &mut PlotUi) {
-        for roi in &self.rois {
+        for (i, roi) in self.rois.iter().enumerate() {
             if !roi.visibility.visible {
                 continue;
             }
@@ -602,27 +602,27 @@ impl RoiState {
             if let RoiShape::Polygon { vertices } = &roi.shape {
                 if polygon_is_convex(vertices) {
                     let points = roi.plot_points();
-                    plot_ui.polygon(Polygon::new(points).stroke(stroke).fill_color(fill));
+                    plot_ui.polygon(Polygon::new(format!("roi_{i}_poly"), points).stroke(stroke).fill_color(fill));
                 } else {
                     let triangles = triangulate_polygon(vertices);
                     if triangles.is_empty() {
                         let line_points = roi.closed_line_points();
                         plot_ui.line(
-                            Line::new(PlotPoints::new(line_points))
+                            Line::new(format!("roi_{i}_line"), PlotPoints::new(line_points))
                                 .color(roi.color)
                                 .width(stroke_width),
                         );
                     } else {
-                        for tri in triangles {
+                        for (ti, tri) in triangles.iter().enumerate() {
                             plot_ui.polygon(
-                                Polygon::new(vec![tri[0], tri[1], tri[2]])
+                                Polygon::new(format!("roi_{i}_tri_{ti}"), vec![tri[0], tri[1], tri[2]])
                                     .stroke(Stroke::new(0.0, Color32::TRANSPARENT))
                                     .fill_color(fill),
                             );
                         }
                         let line_points = roi.closed_line_points();
                         plot_ui.line(
-                            Line::new(PlotPoints::new(line_points))
+                            Line::new(format!("roi_{i}_outline"), PlotPoints::new(line_points))
                                 .color(roi.color)
                                 .width(stroke_width),
                         );
@@ -630,12 +630,12 @@ impl RoiState {
                 }
             } else {
                 let points = roi.plot_points();
-                plot_ui.polygon(Polygon::new(points).stroke(stroke).fill_color(fill));
+                plot_ui.polygon(Polygon::new(format!("roi_{i}_shape"), points).stroke(stroke).fill_color(fill));
             }
 
             let label_pos = roi.label_position();
             plot_ui.text(
-                Text::new(label_pos, roi.name.clone())
+                Text::new(format!("roi_{i}_label"), label_pos, roi.name.clone())
                     .color(roi.color)
                     .anchor(Align2::LEFT_TOP),
             );
@@ -644,7 +644,7 @@ impl RoiState {
                 let handle_points = roi.handle_points();
                 if !handle_points.is_empty() {
                     plot_ui.points(
-                        Points::new(handle_points)
+                        Points::new(format!("roi_{i}_handles"), handle_points)
                             .color(roi.color)
                             .shape(MarkerShape::Square)
                             .radius(3.0),
@@ -661,7 +661,7 @@ impl RoiState {
             let stroke = Stroke::new(1.0, color);
             let fill = roi_fill_color(color);
             let points = draft_plot_points(draft);
-            plot_ui.polygon(Polygon::new(points).stroke(stroke).fill_color(fill));
+            plot_ui.polygon(Polygon::new("draft", points).stroke(stroke).fill_color(fill));
         }
 
         if let Some(draft) = &self.polygon_draft {
@@ -672,11 +672,11 @@ impl RoiState {
                 if let Some(hover) = draft.hover {
                     line_points.push([hover.x, hover.y]);
                 }
-                plot_ui.line(Line::new(PlotPoints::new(line_points)).color(color));
+                plot_ui.line(Line::new("draft_poly_line", PlotPoints::new(line_points)).color(color));
                 let handle_points: Vec<[f64; 2]> =
                     draft.vertices.iter().map(|(x, y)| [*x, *y]).collect();
                 plot_ui.points(
-                    Points::new(handle_points)
+                    Points::new("draft_poly_handles", handle_points)
                         .color(color)
                         .shape(MarkerShape::Circle)
                         .radius(3.0),

--- a/rustpix-gui/src/viewer/roi.rs
+++ b/rustpix-gui/src/viewer/roi.rs
@@ -602,7 +602,11 @@ impl RoiState {
             if let RoiShape::Polygon { vertices } = &roi.shape {
                 if polygon_is_convex(vertices) {
                     let points = roi.plot_points();
-                    plot_ui.polygon(Polygon::new(format!("roi_{i}_poly"), points).stroke(stroke).fill_color(fill));
+                    plot_ui.polygon(
+                        Polygon::new(format!("roi_{i}_poly"), points)
+                            .stroke(stroke)
+                            .fill_color(fill),
+                    );
                 } else {
                     let triangles = triangulate_polygon(vertices);
                     if triangles.is_empty() {
@@ -615,9 +619,12 @@ impl RoiState {
                     } else {
                         for (ti, tri) in triangles.iter().enumerate() {
                             plot_ui.polygon(
-                                Polygon::new(format!("roi_{i}_tri_{ti}"), vec![tri[0], tri[1], tri[2]])
-                                    .stroke(Stroke::new(0.0, Color32::TRANSPARENT))
-                                    .fill_color(fill),
+                                Polygon::new(
+                                    format!("roi_{i}_tri_{ti}"),
+                                    vec![tri[0], tri[1], tri[2]],
+                                )
+                                .stroke(Stroke::new(0.0, Color32::TRANSPARENT))
+                                .fill_color(fill),
                             );
                         }
                         let line_points = roi.closed_line_points();
@@ -630,7 +637,11 @@ impl RoiState {
                 }
             } else {
                 let points = roi.plot_points();
-                plot_ui.polygon(Polygon::new(format!("roi_{i}_shape"), points).stroke(stroke).fill_color(fill));
+                plot_ui.polygon(
+                    Polygon::new(format!("roi_{i}_shape"), points)
+                        .stroke(stroke)
+                        .fill_color(fill),
+                );
             }
 
             let label_pos = roi.label_position();
@@ -661,7 +672,11 @@ impl RoiState {
             let stroke = Stroke::new(1.0, color);
             let fill = roi_fill_color(color);
             let points = draft_plot_points(draft);
-            plot_ui.polygon(Polygon::new("draft", points).stroke(stroke).fill_color(fill));
+            plot_ui.polygon(
+                Polygon::new("draft", points)
+                    .stroke(stroke)
+                    .fill_color(fill),
+            );
         }
 
         if let Some(draft) = &self.polygon_draft {
@@ -672,7 +687,8 @@ impl RoiState {
                 if let Some(hover) = draft.hover {
                     line_points.push([hover.x, hover.y]);
                 }
-                plot_ui.line(Line::new("draft_poly_line", PlotPoints::new(line_points)).color(color));
+                plot_ui
+                    .line(Line::new("draft_poly_line", PlotPoints::new(line_points)).color(color));
                 let handle_points: Vec<[f64; 2]> =
                     draft.vertices.iter().map(|(x, y)| [*x, *y]).collect();
                 plot_ui.points(


### PR DESCRIPTION
Closes #125

## Summary
- Upgrade egui/eframe/egui_extras from 0.29 to 0.33 and egui_plot from 0.29 to 0.34
- Migrate all breaking API changes across 4 major releases: `Rounding` → `CornerRadius`, `Margin` integer fields, `StrokeKind` parameter, `ImageButton` → `Button::image`, `SelectableLabel` removal, plot constructor name parameters, `Frame::new()`, `MenuButton`, and more
- Fix reset-view regression caused by egui_plot 0.34's new `auto_bounds` semantics

## Changes
- **rustpix-gui/Cargo.toml** — version bumps
- **rustpix-gui/src/ui/theme.rs** — `CornerRadius` migration, widget visuals field rename
- **rustpix-gui/src/ui/main_view.rs** — heaviest: all API migrations + reset-view fix
- **rustpix-gui/src/ui/control_panel.rs** — API migrations, `MenuButton`, font access
- **rustpix-gui/src/viewer/roi.rs** — plot constructor name parameters
- **rustpix-gui/src/app.rs** — `ColorImage::new` signature change
- **rustpix-gui/src/main.rs** — `SizeHint` struct variant, SVG loader options
- **Cargo.lock** — dependency resolution

## Test plan
- [x] `cargo build -p rustpix-gui` succeeds with zero warnings
- [x] `cargo clippy -p rustpix-gui` passes with zero lints
- [x] Load an image and verify histogram plot displays correctly
- [x] Click "Reset View" and verify full image with padding is shown
- [ ] Zoom/pan the histogram and verify it persists across frames
- [ ] Double-click to reset view works
- [ ] ROI selection (rectangle and polygon) works
- [ ] Light/dark theme switching works
- [ ] Spectrum plot renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)