### PR TITLE
Fix clippy float-literal-f32-fallback (rustc 1.97) + README concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/badge/docs-mdBook-blue.svg)](https://ornlneutronimaging.github.io/rustpix/)
 [![Crates.io](https://img.shields.io/crates/v/rustpix-core.svg)](https://crates.io/crates/rustpix-core)
 [![PyPI](https://img.shields.io/pypi/v/rustpix.svg)](https://pypi.org/project/rustpix/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18496371.svg)](https://doi.org/10.5281/zenodo.18496371)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18496370.svg)](https://doi.org/10.5281/zenodo.18496370)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 High-performance pixel detector data processing for neutron imaging. Supports Timepix3 (TPX3) with 96M+ hits/sec throughput. Features multiple clustering algorithms, centroid extraction, and Python bindings.
@@ -232,7 +232,7 @@ If you use rustpix in your research, please cite:
   author = {{ORNL Neutron Imaging Team}},
   year = {2026},
   url = {https://github.com/ornlneutronimaging/rustpix},
-  doi = {10.5281/zenodo.18496371}
+  doi = {10.5281/zenodo.18496370}
 }
 ```
 

--- a/rustpix-gui/src/ui/control_panel.rs
+++ b/rustpix-gui/src/ui/control_panel.rs
@@ -226,7 +226,7 @@ impl RustpixApp {
         // Container frame for the toggle group
         egui::Frame::new()
             .fill(colors.bg_dark)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::same(2))
             .show(ui, |ui| {
@@ -517,7 +517,7 @@ impl RustpixApp {
 
         egui::Frame::new()
             .fill(colors.bg_dark)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::same(2))
             .show(ui, |ui| {
@@ -703,7 +703,7 @@ impl RustpixApp {
                 ui.painter().rect_stroke(
                     rect,
                     CornerRadius::same(3),
-                    Stroke::new(1.0, colors.border_light),
+                    Stroke::new(1.0_f32, colors.border_light),
                     StrokeKind::Inside,
                 );
                 ui.painter().rect_filled(rect, CornerRadius::same(3), fill);
@@ -730,7 +730,7 @@ impl RustpixApp {
             ui.painter().hline(
                 header_rect.x_range(),
                 header_rect.bottom(),
-                Stroke::new(1.0, colors.border),
+                Stroke::new(1.0_f32, colors.border),
             );
 
             // Content
@@ -752,7 +752,7 @@ impl RustpixApp {
             ui.painter().hline(
                 last_rect.x_range(),
                 last_rect.bottom(),
-                Stroke::new(1.0, colors.border),
+                Stroke::new(1.0_f32, colors.border),
             );
         });
     }
@@ -870,7 +870,7 @@ impl RustpixApp {
                 .add(
                     egui::Button::new("⚙")
                         .fill(Color32::TRANSPARENT)
-                        .stroke(Stroke::new(1.0, colors.border_light))
+                        .stroke(Stroke::new(1.0_f32, colors.border_light))
                         .corner_radius(CornerRadius::same(4)),
                 )
                 .on_hover_text("Algorithm parameters")
@@ -886,7 +886,7 @@ impl RustpixApp {
         ui.add_space(8.0);
         egui::Frame::new()
             .fill(colors.bg_header)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::same(12))
             .show(ui, |ui| {
@@ -1093,7 +1093,7 @@ impl RustpixApp {
                         ui.add(
                             egui::Button::new("?")
                                 .fill(Color32::TRANSPARENT)
-                                .stroke(Stroke::new(1.0, colors.border_light))
+                                .stroke(Stroke::new(1.0_f32, colors.border_light))
                                 .corner_radius(CornerRadius::same(4)),
                         )
                         .on_hover_text(

--- a/rustpix-gui/src/ui/main_view.rs
+++ b/rustpix-gui/src/ui/main_view.rs
@@ -475,7 +475,7 @@ impl RustpixApp {
             ui.painter().rect_stroke(
                 rect,
                 CornerRadius::same(4),
-                Stroke::new(1.0, colors.border),
+                Stroke::new(1.0_f32, colors.border),
                 StrokeKind::Inside,
             );
 
@@ -596,7 +596,7 @@ impl RustpixApp {
                 )
                 .min_size(egui::vec2(0.0, 28.0))
                 .fill(Color32::TRANSPARENT)
-                .stroke(Stroke::new(1.0, colors.border_light))
+                .stroke(Stroke::new(1.0_f32, colors.border_light))
                 .corner_radius(CornerRadius::same(4));
 
                 if ui
@@ -633,7 +633,7 @@ impl RustpixApp {
                 } else {
                     Color32::TRANSPARENT
                 })
-                .stroke(Stroke::new(1.0, colors.border_light))
+                .stroke(Stroke::new(1.0_f32, colors.border_light))
                 .corner_radius(CornerRadius::same(4));
 
                 if ui.add(grid_btn).on_hover_text("Toggle grid").clicked() {
@@ -707,7 +707,7 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             })
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         ui.add(btn)
     }
@@ -815,7 +815,7 @@ impl RustpixApp {
         };
         egui::Frame::new()
             .fill(no_data_bg)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
@@ -974,7 +974,7 @@ impl RustpixApp {
                     };
                     let hot_points = Points::new("hot_pixels", PlotPoints::new(hot_points))
                         .shape(MarkerShape::Square)
-                        .radius(2.0)
+                        .radius(2.0_f32)
                         .color(accent::RED)
                         .allow_hover(false);
                     plot_ui.points(hot_points);
@@ -1346,7 +1346,7 @@ impl RustpixApp {
         painter.rect_stroke(
             rect,
             CornerRadius::same(2),
-            Stroke::new(1.0, Color32::from_rgb(58, 130, 246)),
+            Stroke::new(1.0_f32, Color32::from_rgb(58, 130, 246)),
             StrokeKind::Inside,
         );
     }
@@ -1390,7 +1390,7 @@ impl RustpixApp {
             painter.rect_stroke(
                 rect.1,
                 CornerRadius::ZERO,
-                Stroke::new(1.0, colors.border),
+                Stroke::new(1.0_f32, colors.border),
                 StrokeKind::Inside,
             );
 
@@ -1407,7 +1407,7 @@ impl RustpixApp {
     fn render_roi_toolbar(&mut self, ui: &mut egui::Ui) {
         let colors = ThemeColors::from_ui(ui);
         egui::Frame::new()
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::symmetric(4, 2))
             .show(ui, |ui| {
@@ -1442,7 +1442,7 @@ impl RustpixApp {
         let menu_button = egui::Button::new("")
             .min_size(egui::vec2(34.0, 22.0))
             .fill(Color32::TRANSPARENT)
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let menu_response =
             egui::containers::menu::MenuButton::from_button(menu_button).ui(ui, |ui| {
@@ -1505,7 +1505,7 @@ impl RustpixApp {
         let gear_button = egui::Button::new("")
             .min_size(egui::vec2(28.0, 22.0))
             .fill(Color32::TRANSPARENT)
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let gear_response =
             egui::containers::menu::MenuButton::from_button(gear_button).ui(ui, |ui| {
@@ -1523,7 +1523,7 @@ impl RustpixApp {
         let help_button = egui::Button::new("?")
             .min_size(egui::vec2(24.0, 22.0))
             .fill(Color32::TRANSPARENT)
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let response = ui.add(help_button);
         if response.clicked() {
@@ -1635,7 +1635,7 @@ impl RustpixApp {
         let mut actions = SpectrumToolbarActions::default();
         egui::Frame::new()
             .fill(colors.bg_panel)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::symmetric(12, 8))
             .show(ui, |ui| {
@@ -1717,7 +1717,7 @@ impl RustpixApp {
             .add(
                 egui::Button::new("⚙")
                     .fill(Color32::TRANSPARENT)
-                    .stroke(Stroke::new(1.0, colors.border_light))
+                    .stroke(Stroke::new(1.0_f32, colors.border_light))
                     .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Spectrum settings")
@@ -1736,7 +1736,7 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             })
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let data_response = ui.add(data_button);
         let data_icon = Self::roi_icon_image(RoiToolbarIcon::Data, colors.text_muted);
@@ -1759,7 +1759,7 @@ impl RustpixApp {
                 .color(colors.text_dim),
         )
         .fill(Color32::TRANSPARENT)
-        .stroke(Stroke::new(1.0, colors.border_light))
+        .stroke(Stroke::new(1.0_f32, colors.border_light))
         .corner_radius(CornerRadius::same(4));
         if ui.add(range_btn).clicked() {
             let opening = !self.ui_state.panel_popups.show_spectrum_range;
@@ -1778,7 +1778,7 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             })
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         if ui.add(help_button).on_hover_text("Spectrum help").clicked() {
             self.ui_state.panel_popups.show_spectrum_help =
@@ -1800,7 +1800,7 @@ impl RustpixApp {
                 .color(colors.text_dim),
         )
         .fill(Color32::TRANSPARENT)
-        .stroke(Stroke::new(1.0, colors.border_light))
+        .stroke(Stroke::new(1.0_f32, colors.border_light))
         .corner_radius(CornerRadius::same(4));
         if ui
             .add_enabled(has_full_spectrum, png_btn)
@@ -1816,7 +1816,7 @@ impl RustpixApp {
                 .color(colors.text_dim),
         )
         .fill(Color32::TRANSPARENT)
-        .stroke(Stroke::new(1.0, colors.border_light))
+        .stroke(Stroke::new(1.0_f32, colors.border_light))
         .corner_radius(CornerRadius::same(4));
         if ui
             .add_enabled(has_visible_spectrum, csv_btn)
@@ -1844,7 +1844,7 @@ impl RustpixApp {
                             .color(colors.text_muted),
                     )
                     .fill(Color32::TRANSPARENT)
-                    .stroke(Stroke::new(1.0, colors.border_light))
+                    .stroke(Stroke::new(1.0_f32, colors.border_light))
                     .corner_radius(CornerRadius::same(4)),
                 )
                 .on_hover_text("Reset spectrum view (or double-click)")
@@ -1887,7 +1887,7 @@ impl RustpixApp {
         };
         let button = egui::Button::new(egui::RichText::new(label).size(10.0).color(text_color))
             .fill(fill)
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         ui.add(button).clicked()
     }
@@ -2287,7 +2287,7 @@ impl RustpixApp {
                 plot_ui.vline(
                     VLine::new(format!("Slice {}", inputs.current_tof_bin + 1), slice_x)
                         .color(accent::RED)
-                        .width(1.0)
+                        .width(1.0_f32)
                         .style(egui_plot::LineStyle::Dashed { length: 4.0 }),
                 );
             }
@@ -2391,7 +2391,7 @@ impl RustpixApp {
         };
         egui::Frame::new()
             .fill(no_data_bg)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::same(16))
             .show(ui, |ui| {
@@ -2743,7 +2743,7 @@ impl RustpixApp {
         let colors = ThemeColors::from_ui(ui);
         egui::Frame::new()
             .fill(colors.bg_panel)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(4))
             .inner_margin(egui::Margin::symmetric(10, 6))
             .show(ui, |ui| {
@@ -2832,7 +2832,7 @@ impl RustpixApp {
             } else {
                 Color32::TRANSPARENT
             })
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let response = ui.add(button);
         let image = Self::zoom_icon_image(icon, tint);
@@ -2858,7 +2858,7 @@ impl RustpixApp {
         ui.painter().vline(
             rect.1.center().x,
             rect.1.y_range(),
-            Stroke::new(1.0, colors.border),
+            Stroke::new(1.0_f32, colors.border),
         );
     }
 
@@ -2877,7 +2877,7 @@ impl RustpixApp {
         let button = egui::Button::new("")
             .min_size(egui::vec2(28.0, 22.0))
             .fill(Color32::TRANSPARENT)
-            .stroke(Stroke::new(1.0, colors.border_light))
+            .stroke(Stroke::new(1.0_f32, colors.border_light))
             .corner_radius(CornerRadius::same(4));
         let response = ui.add(button);
         let image = Self::roi_icon_image(icon, colors.text_muted);

--- a/rustpix-gui/src/ui/statistics.rs
+++ b/rustpix-gui/src/ui/statistics.rs
@@ -60,7 +60,7 @@ impl RustpixApp {
                     ui.painter().hline(
                         ui.available_rect_before_wrap().x_range(),
                         ui.cursor().top(),
-                        Stroke::new(1.0, colors.border),
+                        Stroke::new(1.0_f32, colors.border),
                     );
                 });
                 ui.add_space(8.0);

--- a/rustpix-gui/src/ui/theme.rs
+++ b/rustpix-gui/src/ui/theme.rs
@@ -142,32 +142,32 @@ fn build_dark_visuals() -> Visuals {
     visuals.extreme_bg_color = dark::BG_INPUT;
 
     visuals.widgets.noninteractive.bg_fill = dark::BG_INPUT;
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, dark::TEXT_MUTED);
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, dark::BORDER);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, dark::TEXT_MUTED);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, dark::BORDER);
     visuals.widgets.noninteractive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.inactive.bg_fill = dark::BG_INPUT;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, dark::BORDER_LIGHT);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, dark::TEXT_PRIMARY);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, dark::BORDER_LIGHT);
     visuals.widgets.inactive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.hovered.bg_fill = dark::BUTTON_HOVER;
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, dark::TEXT_PRIMARY);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, accent::BLUE);
     visuals.widgets.hovered.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.active.bg_fill = accent::BLUE;
-    visuals.widgets.active.fg_stroke = Stroke::new(1.0, Color32::WHITE);
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.widgets.active.fg_stroke = Stroke::new(1.0_f32, Color32::WHITE);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, accent::BLUE);
     visuals.widgets.active.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.open.bg_fill = dark::BG_INPUT;
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, dark::TEXT_PRIMARY);
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, dark::BORDER_LIGHT);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, dark::TEXT_PRIMARY);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, dark::BORDER_LIGHT);
     visuals.widgets.open.corner_radius = CornerRadius::same(4);
 
     visuals.selection.bg_fill = accent::BLUE.gamma_multiply(0.3);
-    visuals.selection.stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.selection.stroke = Stroke::new(1.0_f32, accent::BLUE);
 
     visuals
 }
@@ -182,32 +182,32 @@ fn build_light_visuals() -> Visuals {
     visuals.extreme_bg_color = light::BG_INPUT;
 
     visuals.widgets.noninteractive.bg_fill = light::BG_INPUT;
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, light::TEXT_MUTED);
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, light::BORDER);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, light::TEXT_MUTED);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, light::BORDER);
     visuals.widgets.noninteractive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.inactive.bg_fill = light::BG_INPUT;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, light::BORDER_LIGHT);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, light::TEXT_PRIMARY);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, light::BORDER_LIGHT);
     visuals.widgets.inactive.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.hovered.bg_fill = light::BUTTON_HOVER;
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, light::TEXT_PRIMARY);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, accent::BLUE);
     visuals.widgets.hovered.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.active.bg_fill = accent::BLUE;
-    visuals.widgets.active.fg_stroke = Stroke::new(1.0, Color32::WHITE);
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.widgets.active.fg_stroke = Stroke::new(1.0_f32, Color32::WHITE);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, accent::BLUE);
     visuals.widgets.active.corner_radius = CornerRadius::same(4);
 
     visuals.widgets.open.bg_fill = light::BG_INPUT;
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, light::TEXT_PRIMARY);
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, light::BORDER_LIGHT);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, light::TEXT_PRIMARY);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, light::BORDER_LIGHT);
     visuals.widgets.open.corner_radius = CornerRadius::same(4);
 
     visuals.selection.bg_fill = accent::BLUE.gamma_multiply(0.2);
-    visuals.selection.stroke = Stroke::new(1.0, accent::BLUE);
+    visuals.selection.stroke = Stroke::new(1.0_f32, accent::BLUE);
 
     visuals
 }

--- a/rustpix-gui/src/viewer/roi.rs
+++ b/rustpix-gui/src/viewer/roi.rs
@@ -596,7 +596,11 @@ impl RoiState {
                 continue;
             }
             let rid = roi.id;
-            let stroke_width = if roi.selection.selected { 2.0 } else { 1.0 };
+            let stroke_width = if roi.selection.selected {
+                2.0_f32
+            } else {
+                1.0_f32
+            };
             let stroke = Stroke::new(stroke_width, roi.color);
             let fill = roi_fill_color(roi.color);
 
@@ -624,7 +628,7 @@ impl RoiState {
                                     format!("roi_{rid}_tri_{ti}"),
                                     vec![tri[0], tri[1], tri[2]],
                                 )
-                                .stroke(Stroke::new(0.0, Color32::TRANSPARENT))
+                                .stroke(Stroke::new(0.0_f32, Color32::TRANSPARENT))
                                 .fill_color(fill),
                             );
                         }
@@ -659,7 +663,7 @@ impl RoiState {
                         Points::new(format!("roi_{rid}_handles"), handle_points)
                             .color(roi.color)
                             .shape(MarkerShape::Square)
-                            .radius(3.0),
+                            .radius(3.0_f32),
                     );
                 }
             }
@@ -670,7 +674,7 @@ impl RoiState {
     pub fn draw_draft(&self, plot_ui: &mut PlotUi) {
         if let Some(draft) = &self.draft {
             let color = roi_palette_color(self.next_id.saturating_sub(1));
-            let stroke = Stroke::new(1.0, color);
+            let stroke = Stroke::new(1.0_f32, color);
             let fill = roi_fill_color(color);
             let points = draft_plot_points(draft);
             plot_ui.polygon(
@@ -696,7 +700,7 @@ impl RoiState {
                     Points::new("draft_poly_handles", handle_points)
                         .color(color)
                         .shape(MarkerShape::Circle)
-                        .radius(3.0),
+                        .radius(3.0_f32),
                 );
             }
         }


### PR DESCRIPTION
## Why CI is red

CI has been failing since 2026-07-09 — but **not** because of the LICENSE / `.zenodo.json` commits. Those were the first pushes to `main` in 17 days, so they merely re-triggered CI, which surfaced a latent break: Rust `stable` drifted **1.96.0 → 1.97.0** (2026-07-07), and 1.97 added the future-incompat lint `float-literal-f32-fallback` ([rust-lang/rust#154024](https://github.com/rust-lang/rust/issues/154024)). CI runs `cargo clippy --workspace --all-targets -- -D warnings`, which promotes it to a hard error → **64 errors in rustpix-gui**. Only the Clippy job failed; build + tests on all 3 OSes passed.

## Changes

1. **clippy fix** — annotate the 64 flagged float literals as `f32` (`1.0` → `1.0_f32`) in `rustpix-gui` (control_panel, main_view, statistics, theme, viewer/roi), exactly as the lint suggests. No behavior change — `f32` is the type already inferred by fallback. Durable fix (this lint becomes a hard rustc error regardless of clippy), not a blanket `#[allow]`.
2. **README concept DOI** — the DOI badge + BibTeX pointed at the stale v1.0.5 version DOI (`zenodo.18496371`); switch both to the concept DOI `zenodo.18496370`, which always resolves to the latest release, so the badge never needs a per-release update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)